### PR TITLE
fix: 設定画面の選択肢をdesign.mdの仕様に合わせる (#7)

### DIFF
--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -7,9 +7,9 @@ interface SettingsProps {
   onClose: () => void;
 }
 
-const MEDITATION_OPTIONS = [1, 3, 5, 10, 15, 20, 30];
-const JOURNALING_OPTIONS = [30, 60, 90, 120, 180];
-const BREAK_OPTIONS = [5, 10, 15, 20, 30];
+const MEDITATION_OPTIONS = [2, 5, 7, 10, 15];
+const JOURNALING_OPTIONS = [60, 120, 300, 420, 600];
+const BREAK_OPTIONS = [5, 10, 15];
 
 export default function Settings({ onClose }: SettingsProps) {
   const [appSettings, setAppSettings] = useState<AppSettings>(settings.get());

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -70,7 +70,7 @@ export const storage = {
 
     let streak = 0;
     const today = new Date().toISOString().split('T')[0];
-    let currentDate = new Date(today);
+    const currentDate = new Date(today);
 
     for (let i = 0; i < dailyStats.length; i++) {
       const checkDate = currentDate.toISOString().split('T')[0];


### PR DESCRIPTION
## 概要

Issue #7 の対応: 設定画面の選択肢を design.md の仕様に合わせました。

## 変更内容

### Settings.tsx
- **瞑想時間の選択肢**: `2, 5, 7, 10, 15分`
- **メモ書き時間の選択肢**: `1分, 2分, 5分, 7分, 10分` (60, 120, 300, 420, 600秒)
- **休憩時間の選択肢**: `5秒, 10秒, 15秒`

### storage.ts
- ESLintエラー修正: `let currentDate` → `const currentDate`

## ビルド結果

✅ ビルド成功

## 影響範囲

- デフォルト値は変更なし（瞑想: 5分、メモ書き: 60秒、休憩: 10秒）
- 既存のユーザーデータには影響なし
- 設定画面の選択肢のみ変更

Closes #7