### PR TITLE
test: Add History and Settings component tests (#10)

### DIFF
--- a/components/__tests__/History.test.tsx
+++ b/components/__tests__/History.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import History from '../History';
+import { storage } from '@/lib/storage';
+import { Session } from '@/types';
+
+// Mock dependencies
+jest.mock('@/lib/storage');
+
+describe('History', () => {
+  const mockSessions: Session[] = [
+    {
+      id: '1',
+      type: 'meditation',
+      duration: 300, // 5分
+      completedAt: '2026-01-31T10:00:00.000Z',
+    },
+    {
+      id: '2',
+      type: 'journaling',
+      duration: 600, // 10分
+      completedAt: '2026-01-31T11:00:00.000Z',
+    },
+    {
+      id: '3',
+      type: 'meditation',
+      duration: 65, // 1分5秒
+      completedAt: '2026-01-30T09:00:00.000Z',
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // デフォルトのモック実装
+    (storage.getSessions as jest.Mock).mockReturnValue([]);
+    (storage.getStreak as jest.Mock).mockReturnValue(0);
+  });
+
+  describe('初期表示', () => {
+    it('データなし時は「まだ記録がありません」が表示される', () => {
+      render(<History />);
+      expect(screen.getByText('まだ記録がありません')).toBeInTheDocument();
+    });
+
+    it('データあり時はセッション一覧が表示される', () => {
+      (storage.getSessions as jest.Mock).mockReturnValue(mockSessions);
+      render(<History />);
+      expect(screen.queryByText('まだ記録がありません')).not.toBeInTheDocument();
+      expect(screen.getAllByText('瞑想').length).toBeGreaterThan(0);
+      expect(screen.getByText('メモ書き')).toBeInTheDocument();
+    });
+
+    it('初回レンダリング時にstorageからデータを読み込む', () => {
+      render(<History />);
+      expect(storage.getSessions).toHaveBeenCalledTimes(1);
+      expect(storage.getStreak).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('統計カード', () => {
+    beforeEach(() => {
+      (storage.getSessions as jest.Mock).mockReturnValue(mockSessions);
+      (storage.getStreak as jest.Mock).mockReturnValue(5);
+    });
+
+    it('ストリーク（連続記録日数）が表示される', () => {
+      render(<History />);
+      const streakCard = screen.getByText('連続記録日数').parentElement;
+      expect(streakCard).toHaveTextContent('5');
+    });
+
+    it('瞑想回数が正しく集計される', () => {
+      render(<History />);
+      const meditationCard = screen.getByText('瞑想回数').parentElement;
+      expect(meditationCard).toHaveTextContent('2'); // mockSessions内の瞑想は2件
+    });
+
+    it('メモ書き回数が正しく集計される', () => {
+      render(<History />);
+      const journalingCard = screen.getByText('メモ書き回数').parentElement;
+      expect(journalingCard).toHaveTextContent('1'); // mockSessions内のメモ書きは1件
+    });
+
+    it('合計時間（分）が正しく集計される', () => {
+      render(<History />);
+      const totalCard = screen.getByText('合計時間（分）').parentElement;
+      // 300 + 600 + 65 = 965秒 = 16分（切り捨て）
+      expect(totalCard).toHaveTextContent('16');
+    });
+  });
+
+  describe('セッション表示', () => {
+    beforeEach(() => {
+      (storage.getSessions as jest.Mock).mockReturnValue(mockSessions);
+    });
+
+    it('瞑想セッションは紫のバッジで表示される', () => {
+      render(<History />);
+      const meditationBadges = screen.getAllByText('瞑想');
+      meditationBadges.forEach((badge) => {
+        expect(badge).toHaveClass('bg-purple-200', 'text-purple-800');
+      });
+    });
+
+    it('メモ書きセッションは青のバッジで表示される', () => {
+      render(<History />);
+      const journalingBadge = screen.getByText('メモ書き');
+      expect(journalingBadge).toHaveClass('bg-blue-200', 'text-blue-800');
+    });
+  });
+
+  describe('削除機能', () => {
+    beforeEach(() => {
+      (storage.getSessions as jest.Mock).mockReturnValue(mockSessions);
+      jest.spyOn(window, 'confirm');
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('削除ボタンクリック時に確認ダイアログが表示され、キャンセルすると削除されない', () => {
+      (window.confirm as jest.Mock).mockReturnValue(false);
+      render(<History />);
+
+      const deleteButtons = screen.getAllByText('削除');
+      fireEvent.click(deleteButtons[0]);
+
+      expect(window.confirm).toHaveBeenCalledWith('この記録を削除しますか?');
+      expect(storage.deleteSession).not.toHaveBeenCalled();
+    });
+
+    it('削除ボタンクリック時に確認してOKすると削除される', () => {
+      (window.confirm as jest.Mock).mockReturnValue(true);
+      render(<History />);
+
+      const deleteButtons = screen.getAllByText('削除');
+      fireEvent.click(deleteButtons[0]);
+
+      expect(window.confirm).toHaveBeenCalledWith('この記録を削除しますか?');
+      expect(storage.deleteSession).toHaveBeenCalledWith('1');
+      expect(storage.getSessions).toHaveBeenCalledTimes(2); // 初回 + 削除後のリロード
+    });
+  });
+});

--- a/components/__tests__/Settings.test.tsx
+++ b/components/__tests__/Settings.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import Settings from '../Settings';
+import { settings } from '@/lib/settings';
+
+// Mock dependencies
+jest.mock('@/lib/settings');
+
+describe('Settings', () => {
+  const mockOnClose = jest.fn();
+  const defaultSettings = {
+    meditationDuration: 5,
+    journalingDuration: 120,
+    journalingBreakDuration: 10,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (settings.get as jest.Mock).mockReturnValue(defaultSettings);
+    jest.spyOn(window, 'alert').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('初期表示', () => {
+    it('モーダルが表示される', () => {
+      render(<Settings onClose={mockOnClose} />);
+      expect(screen.getByText('設定')).toBeInTheDocument();
+      expect(screen.getByText('瞑想の時間')).toBeInTheDocument();
+      expect(screen.getByText('メモ書きの時間（1ページあたり）')).toBeInTheDocument();
+      expect(screen.getByText('休憩時間（ページ間）')).toBeInTheDocument();
+    });
+
+    it('現在の設定値が選択状態で表示される', () => {
+      render(<Settings onClose={mockOnClose} />);
+
+      // 瞑想時間: 5分が選択されている
+      const meditationSection = screen.getByText('瞑想の時間').parentElement!;
+      const meditation5min = within(meditationSection).getAllByRole('button').find(
+        (btn) => btn.textContent === '5分' && btn.className.includes('bg-purple-600')
+      );
+      expect(meditation5min).toHaveClass('bg-purple-600', 'text-white');
+
+      // メモ書き時間: 2分（120秒）が選択されている
+      const journalingSection = screen.getByText('メモ書きの時間（1ページあたり）').parentElement!;
+      const journaling2min = within(journalingSection).getByRole('button', { name: '2分' });
+      expect(journaling2min).toHaveClass('bg-blue-600', 'text-white');
+
+      // 休憩時間: 10秒が選択されている
+      const breakSection = screen.getByText('休憩時間（ページ間）').parentElement!;
+      const break10sec = within(breakSection).getByRole('button', { name: '10秒' });
+      expect(break10sec).toHaveClass('bg-yellow-600', 'text-white');
+    });
+  });
+
+  describe('設定変更', () => {
+    it('瞑想時間を変更できる', () => {
+      render(<Settings onClose={mockOnClose} />);
+      const meditationSection = screen.getByText('瞑想の時間').parentElement!;
+      const meditation10min = within(meditationSection).getByRole('button', { name: '10分' });
+
+      fireEvent.click(meditation10min);
+
+      expect(meditation10min).toHaveClass('bg-purple-600', 'text-white');
+    });
+
+    it('メモ書き時間を変更できる', () => {
+      render(<Settings onClose={mockOnClose} />);
+      const journalingSection = screen.getByText('メモ書きの時間（1ページあたり）').parentElement!;
+      const journaling5min = within(journalingSection).getByRole('button', { name: '5分' });
+
+      fireEvent.click(journaling5min);
+
+      expect(journaling5min).toHaveClass('bg-blue-600', 'text-white');
+    });
+
+    it('休憩時間を変更できる', () => {
+      render(<Settings onClose={mockOnClose} />);
+      const break15sec = screen.getByRole('button', { name: '15秒' });
+
+      fireEvent.click(break15sec);
+
+      expect(break15sec).toHaveClass('bg-yellow-600', 'text-white');
+    });
+  });
+
+  describe('保存・キャンセル', () => {
+    it('保存ボタンをクリックすると設定が保存される', () => {
+      render(<Settings onClose={mockOnClose} />);
+
+      // 設定を変更
+      const meditationSection = screen.getByText('瞑想の時間').parentElement!;
+      const meditation10min = within(meditationSection).getByRole('button', { name: '10分' });
+      fireEvent.click(meditation10min);
+
+      // 保存ボタンをクリック
+      const saveButton = screen.getByRole('button', { name: '保存' });
+      fireEvent.click(saveButton);
+
+      expect(settings.save).toHaveBeenCalledWith({
+        ...defaultSettings,
+        meditationDuration: 10,
+      });
+    });
+
+    it('保存ボタンをクリックするとアラートが表示される', () => {
+      render(<Settings onClose={mockOnClose} />);
+
+      const saveButton = screen.getByRole('button', { name: '保存' });
+      fireEvent.click(saveButton);
+
+      expect(window.alert).toHaveBeenCalledWith('設定を保存しました');
+    });
+
+    it('保存ボタンをクリックするとonCloseが呼ばれる', () => {
+      render(<Settings onClose={mockOnClose} />);
+
+      const saveButton = screen.getByRole('button', { name: '保存' });
+      fireEvent.click(saveButton);
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('キャンセルボタンをクリックすると設定が保存されない', () => {
+      render(<Settings onClose={mockOnClose} />);
+
+      // 設定を変更
+      const meditationSection = screen.getByText('瞑想の時間').parentElement!;
+      const meditation10min = within(meditationSection).getByRole('button', { name: '10分' });
+      fireEvent.click(meditation10min);
+
+      // キャンセルボタンをクリック
+      const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+      fireEvent.click(cancelButton);
+
+      expect(settings.save).not.toHaveBeenCalled();
+    });
+
+    it('キャンセルボタンをクリックするとonCloseが呼ばれる', () => {
+      render(<Settings onClose={mockOnClose} />);
+
+      const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+      fireEvent.click(cancelButton);
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('✕ボタンをクリックするとonCloseが呼ばれる', () => {
+      render(<Settings onClose={mockOnClose} />);
+
+      const closeButton = screen.getByText('✕');
+      fireEvent.click(closeButton);
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Issue #10の完了: 全コンポーネントの単体テストを追加しました。

## Changes
- **History.test.tsx**（11件のテストケース）
  - 初期表示テスト（データあり/なし）
  - 統計カード（ストリーク、瞑想回数、メモ書き回数、合計時間）
  - セッション表示（瞑想/メモ書きバッジ）
  - 削除機能
- **Settings.test.tsx**（11件のテストケース）
  - 初期表示と現在の設定値
  - 設定変更（瞑想時間、メモ書き時間、休憩時間）
  - 保存/キャンセル機能

## Test Results
✅ 全74件のテスト通過
- MeditationTimer: 14件
- JournalingTimer: 18件
- History: 11件（新規）
- Settings: 11件（新規）

✅ コンポーネントカバレッジ: 97.87%
✅ ビルド成功

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)