### PR TITLE
test: Add lib unit tests and fix getStreak bug

### DIFF
--- a/lib/__tests__/settings.test.ts
+++ b/lib/__tests__/settings.test.ts
@@ -1,0 +1,87 @@
+import { settings, AppSettings } from '../settings';
+
+describe('settings', () => {
+  const defaultSettings: AppSettings = {
+    meditationDuration: 5,
+    journalingDuration: 60,
+    journalingBreakDuration: 10,
+  };
+
+  const customSettings: AppSettings = {
+    meditationDuration: 10,
+    journalingDuration: 120,
+    journalingBreakDuration: 15,
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('get', () => {
+    it('データがない場合はデフォルト設定を返す', () => {
+      expect(settings.get()).toEqual(defaultSettings);
+    });
+
+    it('保存された設定を返す', () => {
+      localStorage.setItem('meditation-journaling-settings', JSON.stringify(customSettings));
+
+      expect(settings.get()).toEqual(customSettings);
+    });
+
+    it('部分的な設定でもデフォルト値とマージされる', () => {
+      const partialSettings = { meditationDuration: 15 };
+      localStorage.setItem('meditation-journaling-settings', JSON.stringify(partialSettings));
+
+      const result = settings.get();
+
+      expect(result.meditationDuration).toBe(15);
+      expect(result.journalingDuration).toBe(60); // デフォルト値
+      expect(result.journalingBreakDuration).toBe(10); // デフォルト値
+    });
+
+    it('無効なJSONの場合はデフォルト設定を返す', () => {
+      localStorage.setItem('meditation-journaling-settings', 'invalid json');
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      expect(settings.get()).toEqual(defaultSettings);
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to load settings:', expect.any(Error));
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('save', () => {
+    it('設定を保存する', () => {
+      settings.save(customSettings);
+
+      const saved = JSON.parse(localStorage.getItem('meditation-journaling-settings')!);
+      expect(saved).toEqual(customSettings);
+    });
+
+    it('部分的な更新でも既存の設定を保持する', () => {
+      settings.save(customSettings);
+      settings.save({ meditationDuration: 7 });
+
+      const result = settings.get();
+
+      expect(result.meditationDuration).toBe(7);
+      expect(result.journalingDuration).toBe(120); // customSettingsの値を保持
+      expect(result.journalingBreakDuration).toBe(15); // customSettingsの値を保持
+    });
+
+    it('LocalStorageへの保存に失敗した場合はエラーをログ出力する', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('Storage quota exceeded');
+      });
+
+      settings.save(customSettings);
+
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to save settings:', expect.any(Error));
+
+      consoleSpy.mockRestore();
+      jest.restoreAllMocks();
+    });
+  });
+});

--- a/lib/__tests__/storage.test.ts
+++ b/lib/__tests__/storage.test.ts
@@ -1,0 +1,211 @@
+import { storage } from '../storage';
+import { Session } from '@/types';
+
+describe('storage', () => {
+  const mockSession1: Session = {
+    id: '1',
+    type: 'meditation',
+    duration: 300,
+    completedAt: '2026-02-01T10:00:00.000Z',
+  };
+
+  const mockSession2: Session = {
+    id: '2',
+    type: 'journaling',
+    duration: 600,
+    completedAt: '2026-02-01T15:00:00.000Z',
+  };
+
+  const mockSession3: Session = {
+    id: '3',
+    type: 'meditation',
+    duration: 420,
+    completedAt: '2026-01-31T09:00:00.000Z',
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('getSessions', () => {
+    it('データがない場合は空配列を返す', () => {
+      expect(storage.getSessions()).toEqual([]);
+    });
+
+    it('保存されたセッションを返す', () => {
+      const sessions = [mockSession1, mockSession2];
+      localStorage.setItem('meditation-journaling-sessions', JSON.stringify(sessions));
+
+      expect(storage.getSessions()).toEqual(sessions);
+    });
+
+    it('無効なJSONの場合は空配列を返す', () => {
+      localStorage.setItem('meditation-journaling-sessions', 'invalid json');
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      expect(storage.getSessions()).toEqual([]);
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to load sessions:', expect.any(Error));
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('saveSession', () => {
+    it('セッションを配列の先頭に追加する', () => {
+      storage.saveSession(mockSession1);
+
+      const sessions = storage.getSessions();
+      expect(sessions).toEqual([mockSession1]);
+    });
+
+    it('既存のセッションを保持しながら新しいセッションを先頭に追加する', () => {
+      storage.saveSession(mockSession1);
+      storage.saveSession(mockSession2);
+
+      const sessions = storage.getSessions();
+      expect(sessions).toEqual([mockSession2, mockSession1]);
+    });
+
+    it('LocalStorageへの保存に失敗した場合はエラーをログ出力する', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('Storage quota exceeded');
+      });
+
+      storage.saveSession(mockSession1);
+
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to save session:', expect.any(Error));
+
+      consoleSpy.mockRestore();
+      jest.restoreAllMocks();
+    });
+  });
+
+  describe('deleteSession', () => {
+    beforeEach(() => {
+      storage.saveSession(mockSession1);
+      storage.saveSession(mockSession2);
+      storage.saveSession(mockSession3);
+    });
+
+    it('指定IDのセッションを削除する', () => {
+      storage.deleteSession('2');
+
+      const sessions = storage.getSessions();
+      expect(sessions).toHaveLength(2);
+      expect(sessions.find(s => s.id === '2')).toBeUndefined();
+    });
+
+    it('他のセッションは保持される', () => {
+      storage.deleteSession('2');
+
+      const sessions = storage.getSessions();
+      expect(sessions).toContainEqual(mockSession3);
+      expect(sessions).toContainEqual(mockSession1);
+    });
+
+    it('存在しないIDを指定しても何も削除されない', () => {
+      storage.deleteSession('999');
+
+      const sessions = storage.getSessions();
+      expect(sessions).toHaveLength(3);
+    });
+  });
+
+  describe('getDailyStats', () => {
+    it('セッションがない場合は空配列を返す', () => {
+      expect(storage.getDailyStats()).toEqual([]);
+    });
+
+    it('日付ごとに統計を集計する', () => {
+      storage.saveSession(mockSession1);
+      storage.saveSession(mockSession2);
+      storage.saveSession(mockSession3);
+
+      const stats = storage.getDailyStats();
+
+      expect(stats).toHaveLength(2);
+      expect(stats[0].date).toBe('2026-02-01');
+      expect(stats[1].date).toBe('2026-01-31');
+    });
+
+    it('瞑想とメモ書きのカウントを正しく分ける', () => {
+      storage.saveSession(mockSession1);
+      storage.saveSession(mockSession2);
+
+      const stats = storage.getDailyStats();
+
+      expect(stats[0].meditationCount).toBe(1);
+      expect(stats[0].journalingCount).toBe(1);
+    });
+
+    it('合計時間を正しく計算する', () => {
+      storage.saveSession(mockSession1); // 300秒
+      storage.saveSession(mockSession2); // 600秒
+
+      const stats = storage.getDailyStats();
+
+      expect(stats[0].totalDuration).toBe(900);
+    });
+
+    it('日付の降順でソートされる', () => {
+      storage.saveSession(mockSession3); // 2026-01-31
+      storage.saveSession(mockSession1); // 2026-02-01
+
+      const stats = storage.getDailyStats();
+
+      expect(stats[0].date).toBe('2026-02-01');
+      expect(stats[1].date).toBe('2026-01-31');
+    });
+  });
+
+  describe('getStreak', () => {
+    beforeEach(() => {
+      // 現在の日付をモック
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-02-03T12:00:00.000Z'));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('セッションがない場合は0を返す', () => {
+      expect(storage.getStreak()).toBe(0);
+    });
+
+    it('今日の記録がある場合、今日から連続日数を計算する', () => {
+      // 2/3（今日）、2/2、2/1 の3日連続
+      storage.saveSession({ ...mockSession1, completedAt: '2026-02-03T10:00:00.000Z' });
+      storage.saveSession({ ...mockSession2, completedAt: '2026-02-02T10:00:00.000Z' });
+      storage.saveSession({ ...mockSession3, completedAt: '2026-02-01T10:00:00.000Z' });
+
+      expect(storage.getStreak()).toBe(3);
+    });
+
+    it('今日の記録がない場合、昨日から連続日数を計算する', () => {
+      // 2/2（昨日）、2/1 の2日連続（今日はまだ記録なし）
+      storage.saveSession({ ...mockSession1, completedAt: '2026-02-02T10:00:00.000Z' });
+      storage.saveSession({ ...mockSession2, completedAt: '2026-02-01T10:00:00.000Z' });
+
+      expect(storage.getStreak()).toBe(2);
+    });
+
+    it('途中で途切れた場合、そこで終了する', () => {
+      // 2/3（今日）、2/2、1/31（2/1が抜けている）
+      storage.saveSession({ ...mockSession1, completedAt: '2026-02-03T10:00:00.000Z' });
+      storage.saveSession({ ...mockSession2, completedAt: '2026-02-02T10:00:00.000Z' });
+      storage.saveSession({ ...mockSession3, completedAt: '2026-01-31T10:00:00.000Z' });
+
+      expect(storage.getStreak()).toBe(2);
+    });
+
+    it('昨日も記録がない場合は0を返す', () => {
+      // 2/1の記録のみ（今日も昨日も記録なし）
+      storage.saveSession({ ...mockSession1, completedAt: '2026-02-01T10:00:00.000Z' });
+
+      expect(storage.getStreak()).toBe(0);
+    });
+  });
+});

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -72,7 +72,8 @@ export const storage = {
     const today = new Date().toISOString().split('T')[0];
     const currentDate = new Date(today);
 
-    for (let i = 0; i < dailyStats.length; i++) {
+    // 最大365日分チェック（dailyStats.lengthだと今日がない場合に不足する）
+    for (let i = 0; i < 365; i++) {
       const checkDate = currentDate.toISOString().split('T')[0];
       const hasSession = dailyStats.some(stat => stat.date === checkDate);
 


### PR DESCRIPTION
## Summary
lib（ユーティリティ）の単体テストを追加し、全体のテストカバレッジを96.18%に向上させました。

## Changes
### 追加テスト
- **lib/__tests__/storage.test.ts**（19件のテストケース）
  - getSessions: データ取得、エラーハンドリング
  - saveSession: セッション保存、配列の先頭追加
  - deleteSession: セッション削除、存在しないID処理
  - getDailyStats: 日次統計の集計、ソート
  - getStreak: 連続記録日数の計算（今日あり/なし、途切れた場合）
- **lib/__tests__/settings.test.ts**（7件のテストケース）
  - get: デフォルト設定、保存された設定、マージ
  - save: 設定保存、部分更新

### バグ修正
- **lib/storage.ts** - getStreak()の修正
  - ループ条件を `dailyStats.length` から `365` に変更
  - 今日の記録がない場合に正しく連続日数を計算できるように修正

## Test Results
✅ 全100件のテスト通過（74件 → 100件）
✅ 全体カバレッジ: **96.18%**（72.9% → 96.18%）
  - Statement: 96.18%
  - Branch: 87.37%
  - Function: 94.91%
  - Line: 99.58%

✅ lib カバレッジ: **91.89%**（9.45% → 91.89%）
  - storage.ts: 92.85%（5.35% → 92.85%）
  - settings.ts: 88.88%（22.22% → 88.88%）

✅ ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)