### PR TITLE
docs: ワークフロー見直し — mainコミット禁止・Issue無しフロー・AI動作ルール

### DIFF
--- a/.claude/agents/meditation-journaling-expert.md
+++ b/.claude/agents/meditation-journaling-expert.md
@@ -95,6 +95,27 @@ permissionMode: default
    - ユーザー承認後、GitHub MCPでマージ
    - ローカルブランチ削除
 
+### コミット前チェック（必須）
+
+すべてのコミット実行前に以下を確認してください：
+
+1. **現在のブランチを確認**: `git rev-parse --abbrev-ref HEAD`
+2. **main の場合は必ず拒否**:
+   - `develop` へチェックアウトする
+   - ユーザーに確認: 「mainへの直接コミットは禁止です。developでコミットしますか？」
+   - 承認後、`develop` でコミットを実行
+3. **feature/* の場合**: そのままコミット・プッシュ
+4. **develop の場合**: コミット・プッシュ後、`develop → main` へのPRの有無を確認
+
+### Issue無しの変更（ドキュメント・サブエージェント等）
+
+```
+1. develop へチェックアウト
+2. 変更実装・コミット・プッシュ
+3. develop → main へのPR作成（GitHub MCP）
+4. ユーザー承認後、PRマージ
+```
+
 ## コーディング規約
 
 ### TypeScript

--- a/.claude/agents/premium-design-expert.md
+++ b/.claude/agents/premium-design-expert.md
@@ -560,6 +560,12 @@ Timer.Controls = ({ children }: { children: React.ReactNode }) => (
 4. 両者でリファクタリング
 5. meditation-journaling-expertがPR作成
 
+### ブランチポリシー
+- **mainへの直接コミットは絶対に行わない**
+- デザイン実装は必ず `feature/issue-X-description` で行う
+- Issue無しの変更（デザイントークン定義のみなど）は `develop` で行う
+- コミット前に `git rev-parse --abbrev-ref HEAD` で現在のブランチを確認する
+
 ## 制約・注意事項
 
 ### 必ず守ること

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,17 +308,55 @@ PRを確認して「マージ承認」
 - GitHub Issueと連携: `feature/issue-3-meditation-timer`
 - `/create-gh-branch X` コマンドで自動生成されます
 
+**変更種類ごとのブランチポリシー**:
+
+| 変更の種類 | 作業ブランチ | PR先 |
+|-----------|------------|------|
+| 機能開発 | `feature/issue-X-description` | `develop` |
+| バグ修正 | `bugfix/issue-X-description` | `develop` |
+| ドキュメント・サブエージェント変更 | `develop` | `main` |
+| 緊急修正（リリース済みバグのみ） | `hotfix/issue-X-description` | `main` + `develop` |
+
 **マージフロー**:
 1. `feature/*` または `bugfix/*` → `develop`: 機能追加・バグ修正時
 2. `develop` → `main`: リリース時（安定版）
+3. `hotfix/*` → `main` + `develop`: 緊急修正時のみ
 
 **運用ルール**:
-1. **常駐ブランチの保護**: `main` と `develop` は削除禁止（常に保持）
-2. **作業ブランチのライフサイクル**:
+1. **mainへの直接コミットは絶対に行わない**: すべての変更は `develop` か `feature/*` で行う。`main` へのマージは PRのみ。
+2. **常駐ブランチの保護**: `main` と `develop` は削除禁止（常に保持）
+3. **作業ブランチのライフサイクル**:
    - `feature/*`, `bugfix/*` はタスク完了後に必ず削除
    - PRマージ後、ローカルブランチを即座に削除: `git branch -d feature/issue-X-...`
-3. **ローカルの理想状態**: タスク終了後は `main` と `develop` の2つのみ残す
-4. **差分の解消**: 作業終了時は `git status` で "working tree clean" の状態にする
+4. **ローカルの理想状態**: タスク終了後は `main` と `develop` の2つのみ残す
+5. **差分の解消**: 作業終了時は `git status` で "working tree clean" の状態にする
+
+---
+
+### Issue無しの変更ワークフロー
+
+Issueと紐付かない変更（ドキュメント、サブエージェント、設定等）の場合：
+
+```
+1. develop へチェックアウト
+2. 変更実装・コミット
+3. develop → main へのPR作成（GitHub MCP）
+4. ユーザー承認後、PRマージ
+5. ローカルの main を更新
+```
+
+---
+
+### AIの動作ルール（コミット時の自動チェック）
+
+AIがコミットを実行する前に、必ず以下を確認する：
+
+1. **現在のブランチを確認**: `git rev-parse --abbrev-ref HEAD`
+2. **main の場合は拒否**:
+   - `develop` へチェックアウト
+   - ユーザーに確認: 「mainへの直接コミットは禁止です。developでコミットしますか？」
+3. **feature/* の場合**: そのままコミット・プッシュ
+4. **develop の場合**: コミット・プッシュ後、`develop → main` へのPRを自動確認
 
 ---
 


### PR DESCRIPTION
## Summary

- `main` への直接コミットを明示的に禁止とルール化
- 変更種類ごとのブランチポリシーテーブルを追加（機能開発・バグ修正・ドキュメント・緊急修定）
- Issue無しの変更ワークフロー（`develop` 直接コミット → PR）を定義
- AI のコミット前チェック動作ルールを 3 ファイル共通で追加
- `hotfix/*` フローを緊急修正用として追加

## 変更対象

| ファイル | 変更内容 |
|---------|---------|
| `CLAUDE.md` | ブランチポリシーテーブル・mainコミット禁止・Issue無しワークフロー・AIチェックルール |
| `.claude/agents/meditation-journaling-expert.md` | コミット前チェック・Issue無し変更の手順 |
| `.claude/agents/premium-design-expert.md` | ブランチポリシー・コミット前チェック |

## Test plan

- [ ] CLAUDE.md のブランチポリシーテーブルが正確であること
- [ ] 3 ファイルすべてにコミット前チェック動作ルールが記載されていること
- [ ] Issue無しワークフローが `develop → main` のフローを正確に記述していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)