### PR TITLE
release: ユーザー登録機能をmainにリリース

### DIFF
--- a/app/api/auth/signup/__tests__/route.test.ts
+++ b/app/api/auth/signup/__tests__/route.test.ts
@@ -1,0 +1,187 @@
+import { POST } from '../route';
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (data: unknown, options?: { status?: number }) => ({
+      status: options?.status ?? 200,
+      json: () => Promise.resolve(data),
+    }),
+  },
+}));
+
+jest.mock('@/lib/db', () => ({
+  db: {
+    select: jest.fn(),
+    insert: jest.fn(),
+  },
+  users: { id: 'id', email: 'email', passwordHash: 'password_hash' },
+  userSettings: { userId: 'user_id' },
+}));
+
+jest.mock('drizzle-orm', () => ({
+  eq: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/utils', () => ({
+  hashPassword: jest.fn().mockResolvedValue('hashed-password'),
+}));
+
+import { db } from '@/lib/db';
+import { hashPassword } from '@/lib/auth/utils';
+
+const createMockRequest = (body: unknown): Request =>
+  ({ json: () => Promise.resolve(body) }) as unknown as Request;
+
+describe('POST /api/auth/signup', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // デフォルト: 既存ユーザーなし
+    (db.select as jest.Mock).mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnValue({
+          limit: jest.fn().mockResolvedValue([]),
+        }),
+      }),
+    });
+
+    // デフォルト: insert成功
+    (db.insert as jest.Mock).mockImplementation(() => ({
+      values: jest.fn().mockReturnValue({
+        returning: jest.fn().mockResolvedValue([{ id: 'new-user-id' }]),
+        then: (resolve: (value: unknown) => void, reject?: (reason?: unknown) => void) =>
+          Promise.resolve(undefined).then(resolve, reject),
+      }),
+    }));
+  });
+
+  describe('正常系', () => {
+    it('有効なデータでユーザー登録に成功する', async () => {
+      const request = createMockRequest({
+        email: 'newuser@example.com',
+        password: 'securePass1',
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual({
+        success: true,
+        userId: 'new-user-id',
+      });
+    });
+
+    it('パスワードがハッシュ化される', async () => {
+      const request = createMockRequest({
+        email: 'newuser@example.com',
+        password: 'securePass1',
+      });
+
+      await POST(request);
+
+      expect(hashPassword).toHaveBeenCalledWith('securePass1');
+    });
+
+    it('デフォルト設定が作成される', async () => {
+      const insertedValues: unknown[] = [];
+
+      (db.insert as jest.Mock).mockImplementation(() => ({
+        values: jest.fn((arg: unknown) => {
+          insertedValues.push(arg);
+          return {
+            returning: jest.fn().mockResolvedValue([{ id: 'new-user-id' }]),
+            then: (resolve: (value: unknown) => void) =>
+              Promise.resolve(undefined).then(resolve),
+          };
+        }),
+      }));
+
+      const request = createMockRequest({
+        email: 'newuser@example.com',
+        password: 'securePass1',
+      });
+
+      await POST(request);
+
+      expect(db.insert).toHaveBeenCalledTimes(2);
+      expect(insertedValues[1]).toEqual(
+        expect.objectContaining({
+          userId: 'new-user-id',
+          meditationDuration: 5,
+          journalingDuration: 120,
+          journalingBreakDuration: 10,
+          theme: 'system',
+        })
+      );
+    });
+  });
+
+  describe('異常系: メール重複', () => {
+    it('既存メールで登録時に409エラーを返す', async () => {
+      (db.select as jest.Mock).mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            limit: jest.fn().mockResolvedValue([{ id: 'existing-id', email: 'existing@example.com' }]),
+          }),
+        }),
+      });
+
+      const request = createMockRequest({
+        email: 'existing@example.com',
+        password: 'securePass1',
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(data).toEqual({ error: 'Email already exists' });
+    });
+
+    it('メール重複時にinsertは呼ばれない', async () => {
+      (db.select as jest.Mock).mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            limit: jest.fn().mockResolvedValue([{ id: 'existing-id' }]),
+          }),
+        }),
+      });
+
+      const request = createMockRequest({
+        email: 'existing@example.com',
+        password: 'securePass1',
+      });
+
+      await POST(request);
+
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('異常系: バリデーション', () => {
+    it('無効なメールフォーマットで400エラーを返す', async () => {
+      const request = createMockRequest({
+        email: 'invalid-email',
+        password: 'securePass1',
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('パスワードが短すぎると400エラーを返す', async () => {
+      const request = createMockRequest({
+        email: 'valid@example.com',
+        password: '1234567',
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server';
+import { db, users, userSettings } from '@/lib/db';
+import { eq } from 'drizzle-orm';
+import { hashPassword } from '@/lib/auth/utils';
+import { signupSchema } from '@/lib/auth/validation';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+
+    const result = signupSchema.safeParse(body);
+    if (!result.success) {
+      return NextResponse.json(
+        { error: result.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    const { email, password } = result.data;
+
+    const [existingUser] = await db
+      .select()
+      .from(users)
+      .where(eq(users.email, email))
+      .limit(1);
+
+    if (existingUser) {
+      return NextResponse.json(
+        { error: 'Email already exists' },
+        { status: 409 }
+      );
+    }
+
+    const passwordHash = await hashPassword(password);
+
+    const [newUser] = await db
+      .insert(users)
+      .values({ email, passwordHash })
+      .returning({ id: users.id });
+
+    await db.insert(userSettings).values({
+      userId: newUser.id,
+      meditationDuration: 5,
+      journalingDuration: 120,
+      journalingBreakDuration: 10,
+      theme: 'system',
+    });
+
+    return NextResponse.json({
+      success: true,
+      userId: newUser.id,
+    });
+  } catch (error) {
+    console.error('Signup error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/auth/__tests__/validation.test.ts
+++ b/lib/auth/__tests__/validation.test.ts
@@ -1,0 +1,74 @@
+import { signupSchema } from '../validation';
+
+describe('signupSchema', () => {
+  describe('正常系', () => {
+    it('有効なメールとパスワードで検証に通る', () => {
+      const result = signupSchema.safeParse({
+        email: 'test@example.com',
+        password: 'password123',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('パスワードが正確に8文字で検証に通る', () => {
+      const result = signupSchema.safeParse({
+        email: 'user@test.com',
+        password: '12345678',
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('異常系: email', () => {
+    it('無効なメールフォーマットで検証に失敗する', () => {
+      const result = signupSchema.safeParse({
+        email: 'invalid-email',
+        password: 'password123',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error.issues[0].path).toContain('email');
+    });
+
+    it('メールが空文字で検証に失敗する', () => {
+      const result = signupSchema.safeParse({
+        email: '',
+        password: 'password123',
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('@記号なしのメールで検証に失敗する', () => {
+      const result = signupSchema.safeParse({
+        email: 'testexample.com',
+        password: 'password123',
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('異常系: password', () => {
+    it('パスワードが7文字で検証に失敗する', () => {
+      const result = signupSchema.safeParse({
+        email: 'test@example.com',
+        password: '1234567',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error.issues[0].path).toContain('password');
+    });
+
+    it('パスワードが空文字で検証に失敗する', () => {
+      const result = signupSchema.safeParse({
+        email: 'test@example.com',
+        password: '',
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/lib/auth/validation.ts
+++ b/lib/auth/validation.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const signupSchema = z.object({
+  email: z.string().email('無効なメールフォーマットです'),
+  password: z.string().min(8, 'パスワードは8文字以上である必要があります'),
+});
+
+export type SignupInput = z.infer<typeof signupSchema>;


### PR DESCRIPTION
## Summary

- Issue #15「ユーザー登録機能の実装」を `develop` から `main` へリリースする

## 含む変更

- `POST /api/auth/signup` エンドポイント（メール・パスワード検証、重複チェック、ハッシュ化、デフォルト設定生成）
- Zod `signupSchema`（メールフォーマット・パスワード強度検証）
- バリデーションスキーマテスト 7件・APIエンドポイントテスト 7件

## 確認済み

- 全テスト 121件 通過
- ビルド成功
- curl による動作確認済み（正常系・異常系全シナリオ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)