### PR TITLE
release: ログイン/ログアウトUI機能をmainにリリース

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import Providers from "./providers";
 
 export const metadata: Metadata = {
   title: "瞑想+メモ書き",
@@ -14,7 +15,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body className="antialiased">
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,5 @@
+import AuthForm from '@/components/AuthForm';
+
+export default function LoginPage() {
+  return <AuthForm mode="login" />;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useSession, signOut } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 import MeditationTimer from '@/components/MeditationTimer';
 import JournalingTimer from '@/components/JournalingTimer';
 import History from '@/components/History';
@@ -9,25 +11,53 @@ import Settings from '@/components/Settings';
 type Tab = 'meditation' | 'journaling' | 'history';
 
 export default function Home() {
+  const { status } = useSession();
+  const router = useRouter();
   const [activeTab, setActiveTab] = useState<Tab>('meditation');
   const [refreshKey, setRefreshKey] = useState(0);
   const [showSettings, setShowSettings] = useState(false);
 
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/login');
+    }
+  }, [status, router]);
+
+  if (status === 'loading' || status === 'unauthenticated') {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-gray-600 dark:text-gray-400">読み込み中...</p>
+      </div>
+    );
+  }
+
   const handleComplete = () => {
     setRefreshKey(prev => prev + 1);
+  };
+
+  const handleLogout = async () => {
+    await signOut({ redirect: true, callbackUrl: '/login' });
   };
 
   return (
     <div className="min-h-screen p-8">
       <div className="max-w-6xl mx-auto">
         <header className="text-center mb-8 relative">
-          <button
-            onClick={() => setShowSettings(true)}
-            className="absolute right-0 top-0 px-4 py-2 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors"
-            title="設定"
-          >
-            ⚙️ 設定
-          </button>
+          <div className="absolute right-0 top-0 flex gap-2">
+            <button
+              onClick={() => setShowSettings(true)}
+              className="px-4 py-2 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors"
+              title="設定"
+            >
+              ⚙️ 設定
+            </button>
+            <button
+              onClick={handleLogout}
+              className="px-4 py-2 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors"
+            >
+              ログアウト
+            </button>
+          </div>
           <h1 className="text-4xl font-bold mb-2">瞑想+メモ書き</h1>
           <p className="text-gray-600 dark:text-gray-400">
             日々の瞑想とメモ書きを記録して、習慣化をサポートします

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { SessionProvider } from 'next-auth/react';
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,5 @@
+import AuthForm from '@/components/AuthForm';
+
+export default function SignupPage() {
+  return <AuthForm mode="signup" />;
+}

--- a/components/AuthForm.tsx
+++ b/components/AuthForm.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { signIn } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { signupSchema } from '@/lib/auth/validation';
+
+interface AuthFormProps {
+  mode: 'login' | 'signup';
+}
+
+export default function AuthForm({ mode }: AuthFormProps) {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setIsLoading(true);
+
+    const result = signupSchema.safeParse({ email, password });
+    if (!result.success) {
+      setError(result.error.issues[0].message);
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      if (mode === 'signup') {
+        const response = await fetch('/api/auth/signup', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password }),
+        });
+
+        if (!response.ok) {
+          const data = await response.json();
+          setError(data.error);
+          setIsLoading(false);
+          return;
+        }
+      }
+
+      const loginResult = await signIn('credentials', {
+        email,
+        password,
+        redirect: false,
+      });
+
+      if (!loginResult?.ok) {
+        setError('メールまたはパスワードが不正です');
+        setIsLoading(false);
+        return;
+      }
+
+      router.push('/');
+    } catch {
+      setError('サーバーエラーが発生しました');
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+            {mode === 'login' ? 'ログイン' : '新規登録'}
+          </h1>
+          <p className="mt-2 text-gray-600 dark:text-gray-400">
+            {mode === 'login'
+              ? '瞑想とメモ書きを記録しましょう'
+              : 'アカウントを作成してください'}
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              メールアドレス
+            </label>
+            <input
+              id="email"
+              type="text"
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-600 focus:border-transparent"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              パスワード
+            </label>
+            <input
+              id="password"
+              type="password"
+              autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-purple-600 focus:border-transparent"
+            />
+          </div>
+
+          {error && (
+            <p className="text-red-500 text-sm">{error}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="w-full py-2 px-4 bg-purple-600 text-white font-medium rounded-lg hover:bg-purple-700 disabled:bg-purple-400 disabled:cursor-not-allowed transition-colors"
+          >
+            {isLoading ? '送信中...' : mode === 'login' ? 'ログイン' : '新規登録'}
+          </button>
+        </form>
+
+        <p className="mt-6 text-center text-sm text-gray-600 dark:text-gray-400">
+          {mode === 'login' ? (
+            <>アカウント未持ちの方は<Link href="/signup" className="text-purple-600 hover:underline">登録へ</Link></>
+          ) : (
+            <>アカウント済みの方は<Link href="/login" className="text-purple-600 hover:underline">ログインへ</Link></>
+          )}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/__tests__/AuthForm.test.tsx
+++ b/components/__tests__/AuthForm.test.tsx
@@ -1,0 +1,270 @@
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import AuthForm from '../AuthForm';
+
+jest.mock('next-auth/react', () => ({
+  signIn: jest.fn(),
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(() => ({
+    push: jest.fn(),
+  })),
+}));
+
+import { signIn } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+
+describe('AuthForm', () => {
+  const mockPush = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+  });
+
+  describe('ログインモード', () => {
+    it('「ログイン」見出しが表示される', () => {
+      render(<AuthForm mode="login" />);
+
+      expect(screen.getByRole('heading', { name: 'ログイン' })).toBeInTheDocument();
+    });
+
+    it('サインアップページへのリンクが表示される', () => {
+      render(<AuthForm mode="login" />);
+
+      expect(screen.getByRole('link', { name: '登録へ' })).toHaveAttribute('href', '/signup');
+    });
+
+    it('メール・パスワード入力フィールドが表示される', () => {
+      render(<AuthForm mode="login" />);
+
+      expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument();
+      expect(screen.getByLabelText('パスワード')).toBeInTheDocument();
+    });
+
+    it('有効なデータで送信すると signIn が呼ばれる', async () => {
+      (signIn as jest.Mock).mockResolvedValue({ ok: true });
+
+      render(<AuthForm mode="login" />);
+
+      fireEvent.change(screen.getByLabelText('メールアドレス'), {
+        target: { value: 'test@example.com' },
+      });
+      fireEvent.change(screen.getByLabelText('パスワード'), {
+        target: { value: 'password123' },
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+      });
+
+      expect(signIn).toHaveBeenCalledWith('credentials', {
+        email: 'test@example.com',
+        password: 'password123',
+        redirect: false,
+      });
+    });
+
+    it('ログイン失敗時にエラーメッセージが表示される', async () => {
+      (signIn as jest.Mock).mockResolvedValue({ ok: false });
+
+      render(<AuthForm mode="login" />);
+
+      fireEvent.change(screen.getByLabelText('メールアドレス'), {
+        target: { value: 'test@example.com' },
+      });
+      fireEvent.change(screen.getByLabelText('パスワード'), {
+        target: { value: 'password123' },
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+      });
+
+      expect(screen.getByText('メールまたはパスワードが不正です')).toBeInTheDocument();
+    });
+
+    it('ログイン成功時に / へリダイレクトされる', async () => {
+      (signIn as jest.Mock).mockResolvedValue({ ok: true });
+
+      render(<AuthForm mode="login" />);
+
+      fireEvent.change(screen.getByLabelText('メールアドレス'), {
+        target: { value: 'test@example.com' },
+      });
+      fireEvent.change(screen.getByLabelText('パスワード'), {
+        target: { value: 'password123' },
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+      });
+
+      expect(mockPush).toHaveBeenCalledWith('/');
+    });
+  });
+
+  describe('サインアップモード', () => {
+    let mockFetch: jest.Mock;
+
+    beforeEach(() => {
+      mockFetch = jest.fn();
+      global.fetch = mockFetch as unknown as typeof fetch;
+    });
+
+    it('「新規登録」見出しが表示される', () => {
+      render(<AuthForm mode="signup" />);
+
+      expect(screen.getByRole('heading', { name: '新規登録' })).toBeInTheDocument();
+    });
+
+    it('ログインページへのリンクが表示される', () => {
+      render(<AuthForm mode="signup" />);
+
+      expect(screen.getByRole('link', { name: 'ログインへ' })).toHaveAttribute('href', '/login');
+    });
+
+    it('有効なデータで送信すると /api/auth/signup に POST される', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true, userId: 'test-id' }),
+      });
+      (signIn as jest.Mock).mockResolvedValue({ ok: true });
+
+      render(<AuthForm mode="signup" />);
+
+      fireEvent.change(screen.getByLabelText('メールアドレス'), {
+        target: { value: 'new@example.com' },
+      });
+      fireEvent.change(screen.getByLabelText('パスワード'), {
+        target: { value: 'password123' },
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: '新規登録' }));
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/auth/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'new@example.com', password: 'password123' }),
+      });
+    });
+
+    it('登録成功後に自動ログインとリダイレクトされる', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true, userId: 'test-id' }),
+      });
+      (signIn as jest.Mock).mockResolvedValue({ ok: true });
+
+      render(<AuthForm mode="signup" />);
+
+      fireEvent.change(screen.getByLabelText('メールアドレス'), {
+        target: { value: 'new@example.com' },
+      });
+      fireEvent.change(screen.getByLabelText('パスワード'), {
+        target: { value: 'password123' },
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: '新規登録' }));
+      });
+
+      expect(signIn).toHaveBeenCalledWith('credentials', {
+        email: 'new@example.com',
+        password: 'password123',
+        redirect: false,
+      });
+      expect(mockPush).toHaveBeenCalledWith('/');
+    });
+
+    it('登録失敗時にAPIエラーメッセージが表示される', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({ error: 'Email already exists' }),
+      });
+
+      render(<AuthForm mode="signup" />);
+
+      fireEvent.change(screen.getByLabelText('メールアドレス'), {
+        target: { value: 'existing@example.com' },
+      });
+      fireEvent.change(screen.getByLabelText('パスワード'), {
+        target: { value: 'password123' },
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: '新規登録' }));
+      });
+
+      expect(screen.getByText('Email already exists')).toBeInTheDocument();
+    });
+  });
+
+  describe('バリデーション', () => {
+    it('無効なメールで送信すると検証エラーが表示される', async () => {
+      render(<AuthForm mode="login" />);
+
+      fireEvent.change(screen.getByLabelText('メールアドレス'), {
+        target: { value: 'invalid' },
+      });
+      fireEvent.change(screen.getByLabelText('パスワード'), {
+        target: { value: 'password123' },
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+      });
+
+      expect(screen.getByText('無効なメールフォーマットです')).toBeInTheDocument();
+      expect(signIn).not.toHaveBeenCalled();
+    });
+
+    it('パスワードが短すぎると検証エラーが表示される', async () => {
+      render(<AuthForm mode="login" />);
+
+      fireEvent.change(screen.getByLabelText('メールアドレス'), {
+        target: { value: 'test@example.com' },
+      });
+      fireEvent.change(screen.getByLabelText('パスワード'), {
+        target: { value: '1234567' },
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+      });
+
+      expect(screen.getByText('パスワードは8文字以上である必要があります')).toBeInTheDocument();
+      expect(signIn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ローディング状態', () => {
+    it('送信中はボタンが無効化される', async () => {
+      let resolveSignIn: (value: { ok: boolean }) => void = () => {};
+      (signIn as jest.Mock).mockImplementation(
+        () => new Promise((resolve) => { resolveSignIn = resolve; })
+      );
+
+      render(<AuthForm mode="login" />);
+
+      fireEvent.change(screen.getByLabelText('メールアドレス'), {
+        target: { value: 'test@example.com' },
+      });
+      fireEvent.change(screen.getByLabelText('パスワード'), {
+        target: { value: 'password123' },
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'ログイン' }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: '送信中...' })).toBeDisabled();
+      });
+
+      await act(async () => {
+        resolveSignIn({ ok: true });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Issue #16「ログイン/ログアウトUIの実装」を `develop` から `main` へリリースする

## 含む変更

- `AuthForm` コンポーネント（login/signup モード切り替え・バリデーション・ローディング・エラー表示）
- `/login` ページ・`/signup` ページ（サインアップAPI連携・自動ログイン）
- `SessionProvider` の導入・メインページの未認証リダイレクト・ログアウトボタン
- AuthForm テスト 14件

## 確認済み

- 全テスト 135件 通過
- ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)