### PR TITLE
feat: 認証ミドルウェアの実装 (#17)

### DIFF
--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,0 +1,122 @@
+import middleware from '../middleware';
+
+// auth() のモック
+jest.mock('../auth', () => ({
+  auth: jest.fn(),
+}));
+
+// NextResponse のモック
+const mockRedirect = jest.fn(() => ({ type: 'redirect' }));
+const mockNext = jest.fn(() => ({ type: 'next' }));
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    redirect: (...args: unknown[]) => mockRedirect(...args),
+    next: (...args: unknown[]) => mockNext(...args),
+  },
+  NextRequest: jest.fn(),
+}));
+
+import { auth } from '../auth';
+
+// NextRequest のモッククラス
+function createMockRequest(url: string) {
+  return {
+    nextUrl: new URL(url, 'http://localhost:3000'),
+    url,
+  };
+}
+
+describe('認証ミドルウェア', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('未認証時', () => {
+    beforeEach(() => {
+      (auth as jest.Mock).mockResolvedValue(null);
+    });
+
+    it('保護ルート "/" にアクセスると "/login" へリダイレクトされる', async () => {
+      const request = createMockRequest('http://localhost:3000/');
+      await middleware(request as any);
+
+      expect(mockRedirect).toHaveBeenCalledTimes(1);
+      const redirectUrl = mockRedirect.mock.calls[0][0];
+      expect(redirectUrl.pathname).toBe('/login');
+    });
+
+    it('公開ルート "/login" にアクセスと通過される', async () => {
+      const request = createMockRequest('http://localhost:3000/login');
+      await middleware(request as any);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it('公開ルート "/signup" にアクセスと通過される', async () => {
+      const request = createMockRequest('http://localhost:3000/signup');
+      await middleware(request as any);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it('NextAuth APIルート "/api/auth/signin" にアクセスると通過される', async () => {
+      const request = createMockRequest('http://localhost:3000/api/auth/signin');
+      await middleware(request as any);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it('APIルート "/api/sessions" にアクセスると "/login" へリダイレクトされる', async () => {
+      const request = createMockRequest('http://localhost:3000/api/sessions');
+      await middleware(request as any);
+
+      expect(mockRedirect).toHaveBeenCalledTimes(1);
+      const redirectUrl = mockRedirect.mock.calls[0][0];
+      expect(redirectUrl.pathname).toBe('/login');
+    });
+  });
+
+  describe('認証済みの場合', () => {
+    beforeEach(() => {
+      (auth as jest.Mock).mockResolvedValue({ user: { id: '1', email: 'test@example.com' } });
+    });
+
+    it('保護ルート "/" にアクセスると通過される', async () => {
+      const request = createMockRequest('http://localhost:3000/');
+      await middleware(request as any);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it('"/login" にアクセスると "/" へリダイレクトされる', async () => {
+      const request = createMockRequest('http://localhost:3000/login');
+      await middleware(request as any);
+
+      expect(mockRedirect).toHaveBeenCalledTimes(1);
+      const redirectUrl = mockRedirect.mock.calls[0][0];
+      expect(redirectUrl.pathname).toBe('/');
+    });
+
+    it('"/signup" にアクセスると "/" へリダイレクトされる', async () => {
+      const request = createMockRequest('http://localhost:3000/signup');
+      await middleware(request as any);
+
+      expect(mockRedirect).toHaveBeenCalledTimes(1);
+      const redirectUrl = mockRedirect.mock.calls[0][0];
+      expect(redirectUrl.pathname).toBe('/');
+    });
+
+    it('APIルート "/api/sessions" にアクセスると通過される', async () => {
+      const request = createMockRequest('http://localhost:3000/api/sessions');
+      await middleware(request as any);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { auth } from './auth';
+
+const PUBLIC_ROUTES = ['/login', '/signup'];
+
+export default async function middleware(request: { nextUrl: URL }) {
+  const { nextUrl } = request;
+  const session = await auth();
+
+  // NextAuth APIルートは常に公開
+  if (nextUrl.pathname.startsWith('/api/auth')) {
+    return NextResponse.next();
+  }
+
+  // 公開ルートの処理
+  if (PUBLIC_ROUTES.includes(nextUrl.pathname)) {
+    // 認証済みなら "/" へリダイレクト
+    if (session) {
+      return NextResponse.redirect(new URL('/', nextUrl));
+    }
+    return NextResponse.next();
+  }
+
+  // 保護ルート（それ以外の全ルート）の処理
+  if (!session) {
+    return NextResponse.redirect(new URL('/login', nextUrl));
+  }
+
+  return NextResponse.next();
+}


### PR DESCRIPTION
## 概要
Next.js Middlewareを使った認証保護を実装し、未認証ユーザーのアクセス制御を行う。

## 変更内容

### 新規ファイル
- `middleware.ts` — 認証ミドルウェア
- `__tests__/middleware.test.ts` — Unit Test（9件）

### ルート制御
| ルート | 未認証時 | 認証済みの場合 |
|---|---|---|
| `/` | `/login` へリダイレクト | 通過 |
| `/api/*`（`/api/auth/*` 除く） | `/login` へリダイレクト | 通過 |
| `/login`, `/signup` | 通過 | `/` へリダイレクト |
| `/api/auth/*` | 通過 | 通過 |

## テスト結果
✅ 全9件通過

## ビルド結果
✅ ビルド成功（新規警告なし）

## 受け入れ基準
- [x] 未認証時に保護ルートへアクセスするとログインページへリダイレクトされる
- [x] 認証済み時に保護ルートへアクセスできる
- [x] 公開ルートへは誰でもアクセスできる
- [x] 認証済みで /login・/signup にアクセスると / へリダイレクト
- [x] 全テストが通過する
- [x] ビルドエラーがない

Closes #17