### PR TITLE
feat: ログイン済みユーザー名の表示 (#26)

### DIFF
--- a/app/__tests__/page.test.tsx
+++ b/app/__tests__/page.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import Home from '../page';
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+  signOut: jest.fn(),
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(() => ({
+    push: jest.fn(),
+  })),
+}));
+
+jest.mock('@/components/MeditationTimer', () => {
+  return function MeditationTimer() {
+    return <div>MeditationTimer</div>;
+  };
+});
+
+jest.mock('@/components/JournalingTimer', () => {
+  return function JournalingTimer() {
+    return <div>JournalingTimer</div>;
+  };
+});
+
+jest.mock('@/components/History', () => {
+  return function History() {
+    return <div>History</div>;
+  };
+});
+
+jest.mock('@/components/Settings', () => {
+  return function Settings() {
+    return <div>Settings</div>;
+  };
+});
+
+import { useSession } from 'next-auth/react';
+
+describe('ホームページ', () => {
+  describe('ログイン済みユーザー名の表示', () => {
+    it('メールアドレスのローカルパート部分が表示される', () => {
+      (useSession as jest.Mock).mockReturnValue({
+        data: { user: { id: '1', email: 'testuser@example.com' } },
+        status: 'authenticated',
+      });
+
+      render(<Home />);
+
+      expect(screen.getByText('testuser')).toBeInTheDocument();
+    });
+
+    it('メールアドレス全体ではなくローカルパートのみが表示される', () => {
+      (useSession as jest.Mock).mockReturnValue({
+        data: { user: { id: '1', email: 'myname@gmail.com' } },
+        status: 'authenticated',
+      });
+
+      render(<Home />);
+
+      expect(screen.getByText('myname')).toBeInTheDocument();
+      expect(screen.queryByText('myname@gmail.com')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ import Settings from '@/components/Settings';
 type Tab = 'meditation' | 'journaling' | 'history';
 
 export default function Home() {
-  const { status } = useSession();
+  const { data: session, status } = useSession();
   const router = useRouter();
   const [activeTab, setActiveTab] = useState<Tab>('meditation');
   const [refreshKey, setRefreshKey] = useState(0);
@@ -43,7 +43,10 @@ export default function Home() {
     <div className="min-h-screen p-8">
       <div className="max-w-6xl mx-auto">
         <header className="text-center mb-8 relative">
-          <div className="absolute right-0 top-0 flex gap-2">
+          <div className="absolute right-0 top-0 flex items-center gap-2">
+            <span className="px-2 text-sm text-gray-600 dark:text-gray-400">
+              {session?.user?.email?.split('@')[0]}
+            </span>
             <button
               onClick={() => setShowSettings(true)}
               className="px-4 py-2 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors"


### PR DESCRIPTION
## 概要
ログイン済みユーザーのメールアドレスから、ローカルパート部分をヘッダーに表示する。

## 変更内容

### 変更ファイル
- `app/page.tsx` — `useSession()` から `session` を取り出し、ヘッダーに表示追加

### 新規ファイル
- `app/__tests__/page.test.tsx` — Unit Test（2件）

### 表示仕様
- **表示箇所**: ヘッダー（設定ボタンの左側）
- **表示形式**: `@` 以前のローカルパートのみ（`test@example.com` → `test`）

## テスト結果
✅ 全2件通過

## ビルド結果
✅ ビルド成功

## 受け入れ基準
- [x] ログイン済みユーザー名がヘッダーに表示される
- [x] メールアドレス全体ではなくローカルパートのみが表示される
- [x] 全テストが通過する
- [x] ビルドエラーがない

Closes #26