### PR TITLE
release: develop → main (Issue #19 UIテキスト英語化)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,7 +26,7 @@ export default function Home() {
   if (status === 'loading' || status === 'unauthenticated') {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <p className="text-gray-600 dark:text-gray-400">読み込み中...</p>
+        <p className="text-gray-600 dark:text-gray-400">Loading...</p>
       </div>
     );
   }
@@ -50,20 +50,20 @@ export default function Home() {
             <button
               onClick={() => setShowSettings(true)}
               className="px-4 py-2 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors"
-              title="設定"
+              title="Settings"
             >
-              ⚙️ 設定
+              ⚙️ Settings
             </button>
             <button
               onClick={handleLogout}
               className="px-4 py-2 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors"
             >
-              ログアウト
+              Logout
             </button>
           </div>
-          <h1 className="text-4xl font-bold mb-2">瞑想+メモ書き</h1>
+          <h1 className="text-4xl font-bold mb-2">Meditation + Journaling</h1>
           <p className="text-gray-600 dark:text-gray-400">
-            日々の瞑想とメモ書きを記録して、習慣化をサポートします
+            Track your daily meditation and journaling to build habits
           </p>
         </header>
 
@@ -77,7 +77,7 @@ export default function Home() {
                   : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
               }`}
             >
-              瞑想
+              Meditation
             </button>
             <button
               onClick={() => setActiveTab('journaling')}
@@ -87,7 +87,7 @@ export default function Home() {
                   : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
               }`}
             >
-              メモ書き
+              Journaling
             </button>
             <button
               onClick={() => setActiveTab('history')}
@@ -97,7 +97,7 @@ export default function Home() {
                   : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
               }`}
             >
-              履歴
+              History
             </button>
           </div>
         </div>
@@ -115,7 +115,7 @@ export default function Home() {
         </main>
 
         <footer className="mt-16 text-center text-sm text-gray-500 dark:text-gray-400">
-          <p>毎日の習慣を記録して、自己効力感を高めましょう</p>
+          <p>Build your daily habits one step at a time</p>
         </footer>
       </div>
 

--- a/components/History.tsx
+++ b/components/History.tsx
@@ -18,7 +18,7 @@ export default function History() {
   };
 
   const handleDelete = (id: string) => {
-    if (window.confirm('この記録を削除しますか?')) {
+    if (window.confirm('Delete this record?')) {
       storage.deleteSession(id);
       loadData();
     }
@@ -26,7 +26,7 @@ export default function History() {
 
   const formatDate = (isoString: string) => {
     const date = new Date(isoString);
-    return new Intl.DateTimeFormat('ja-JP', {
+    return new Intl.DateTimeFormat('en-US', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
@@ -38,9 +38,9 @@ export default function History() {
   const formatDuration = (seconds: number) => {
     const mins = Math.floor(seconds / 60);
     const secs = seconds % 60;
-    if (mins === 0) return `${secs}秒`;
-    if (secs === 0) return `${mins}分`;
-    return `${mins}分${secs}秒`;
+    if (mins === 0) return `${secs}s`;
+    if (secs === 0) return `${mins}m`;
+    return `${mins}m${secs}s`;
   };
 
   const getTotalStats = () => {
@@ -57,27 +57,27 @@ export default function History() {
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <div className="bg-gradient-to-br from-orange-500 to-orange-600 text-white p-6 rounded-lg">
           <div className="text-3xl font-bold">{streak}</div>
-          <div className="text-sm opacity-90">連続記録日数</div>
+          <div className="text-sm opacity-90">Streak</div>
         </div>
         <div className="bg-gradient-to-br from-purple-500 to-purple-600 text-white p-6 rounded-lg">
           <div className="text-3xl font-bold">{stats.totalMeditations}</div>
-          <div className="text-sm opacity-90">瞑想回数</div>
+          <div className="text-sm opacity-90">Meditation</div>
         </div>
         <div className="bg-gradient-to-br from-blue-500 to-blue-600 text-white p-6 rounded-lg">
           <div className="text-3xl font-bold">{stats.totalJournalings}</div>
-          <div className="text-sm opacity-90">メモ書き回数</div>
+          <div className="text-sm opacity-90">Journaling</div>
         </div>
         <div className="bg-gradient-to-br from-gray-500 to-gray-600 text-white p-6 rounded-lg">
           <div className="text-3xl font-bold">{Math.floor(stats.totalDuration / 60)}</div>
-          <div className="text-sm opacity-90">合計時間（分）</div>
+          <div className="text-sm opacity-90">Total (min)</div>
         </div>
       </div>
 
       <div className="space-y-3">
-        <h3 className="text-xl font-bold">履歴</h3>
+        <h3 className="text-xl font-bold">History</h3>
         {sessions.length === 0 ? (
           <p className="text-gray-500 dark:text-gray-400 text-center py-8">
-            まだ記録がありません
+            No records yet
           </p>
         ) : (
           <div className="space-y-2">
@@ -95,7 +95,7 @@ export default function History() {
                           : 'bg-blue-200 text-blue-800 dark:bg-blue-900 dark:text-blue-200'
                       }`}
                     >
-                      {session.type === 'meditation' ? '瞑想' : 'メモ書き'}
+                      {session.type === 'meditation' ? 'Meditation' : 'Journaling'}
                     </span>
                     <span className="text-sm text-gray-600 dark:text-gray-400">
                       {formatDuration(session.duration)}
@@ -114,7 +114,7 @@ export default function History() {
                   onClick={() => handleDelete(session.id)}
                   className="ml-4 text-red-500 hover:text-red-700 text-sm"
                 >
-                  削除
+                  Delete
                 </button>
               </div>
             ))}

--- a/components/JournalingTimer.tsx
+++ b/components/JournalingTimer.tsx
@@ -125,7 +125,7 @@ export default function JournalingTimer({ onComplete }: { onComplete?: () => voi
   };
 
   const handleStop = () => {
-    if (window.confirm('メモ書きを終了しますか？')) {
+    if (window.confirm('End journaling?')) {
       handleComplete();
     }
   };
@@ -141,35 +141,35 @@ export default function JournalingTimer({ onComplete }: { onComplete?: () => voi
       {!isRunning ? (
         <>
           <div className="text-center space-y-4">
-            <h2 className="text-3xl font-bold text-blue-600 dark:text-blue-400">メモ書き</h2>
+            <h2 className="text-3xl font-bold text-blue-600 dark:text-blue-400">Journaling</h2>
             <p className="text-2xl font-bold text-blue-700 dark:text-blue-300">
-              {duration < 60 ? `${duration}秒` : `${duration / 60}分`} × {MAX_PAGES}ページ
+              {duration < 60 ? `${duration}s` : `${duration / 60} min`} × {MAX_PAGES} pages
             </p>
             <p className="text-sm text-gray-600 dark:text-gray-400">
-              休憩時間: {breakDuration}秒
+              Break: {breakDuration}s
             </p>
             <p className="text-sm text-gray-600 dark:text-gray-400">
-              設定から時間を変更できます
+              Change duration in Settings
             </p>
           </div>
           <button
             onClick={handleStart}
             className="px-12 py-5 bg-blue-600 text-white rounded-lg font-bold text-xl hover:bg-blue-700 transition-colors shadow-lg"
           >
-            開始
+            Start
           </button>
         </>
       ) : (
         <>
           <div className="text-center space-y-4">
             <div className="text-lg font-medium text-blue-600 dark:text-blue-400">
-              {phase === 'writing' ? `ページ ${currentPage} / ${MAX_PAGES}` : '休憩中'}
+              {phase === 'writing' ? `Page ${currentPage} / ${MAX_PAGES}` : 'Break'}
             </div>
             <div className="text-8xl font-bold tabular-nums text-blue-600 dark:text-blue-400">
               {formatTime(timeLeft)}
             </div>
             <div className="text-base text-gray-600 dark:text-gray-400">
-              {phase === 'writing' ? '紙に書き出しましょう' : '次のページまで休憩'}
+              {phase === 'writing' ? 'Write it out' : 'Rest until next page'}
             </div>
           </div>
 
@@ -195,7 +195,7 @@ export default function JournalingTimer({ onComplete }: { onComplete?: () => voi
             onClick={handleStop}
             className="px-6 py-3 bg-red-600 text-white rounded-lg font-medium hover:bg-red-700 transition-colors"
           >
-            終了
+            End
           </button>
         </>
       )}

--- a/components/MeditationTimer.tsx
+++ b/components/MeditationTimer.tsx
@@ -90,15 +90,15 @@ export default function MeditationTimer({ onComplete }: { onComplete?: () => voi
       {!isRunning ? (
         <>
           <div className="text-center space-y-4">
-            <h2 className="text-3xl font-bold text-purple-600 dark:text-purple-400">瞑想</h2>
-            <p className="text-5xl font-bold text-purple-700 dark:text-purple-300">{duration}分</p>
-            <p className="text-sm text-gray-600 dark:text-gray-400">時間は設定から変更できます</p>
+            <h2 className="text-3xl font-bold text-purple-600 dark:text-purple-400">Meditation</h2>
+            <p className="text-5xl font-bold text-purple-700 dark:text-purple-300">{duration} min</p>
+            <p className="text-sm text-gray-600 dark:text-gray-400">Change duration in Settings</p>
           </div>
           <button
             onClick={handleStart}
             className="px-12 py-5 bg-purple-600 text-white rounded-lg font-bold text-xl hover:bg-purple-700 transition-colors shadow-lg"
           >
-            開始
+            Start
           </button>
         </>
       ) : (
@@ -111,13 +111,13 @@ export default function MeditationTimer({ onComplete }: { onComplete?: () => voi
               onClick={handlePause}
               className="px-6 py-3 bg-yellow-600 text-white rounded-lg font-medium hover:bg-yellow-700 transition-colors"
             >
-              {isPaused ? '再開' : '一時停止'}
+              {isPaused ? 'Resume' : 'Pause'}
             </button>
             <button
               onClick={handleStop}
               className="px-6 py-3 bg-red-600 text-white rounded-lg font-medium hover:bg-red-700 transition-colors"
             >
-              停止
+              Stop
             </button>
           </div>
         </>

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -20,7 +20,7 @@ export default function Settings({ onClose }: SettingsProps) {
 
   const handleSave = () => {
     settings.save(appSettings);
-    alert('設定を保存しました');
+    alert('Settings saved');
     onClose();
   };
 
@@ -28,7 +28,7 @@ export default function Settings({ onClose }: SettingsProps) {
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
       <div className="bg-white dark:bg-gray-800 rounded-lg max-w-md w-full p-6 space-y-6">
         <div className="flex justify-between items-center">
-          <h2 className="text-2xl font-bold">設定</h2>
+          <h2 className="text-2xl font-bold">Settings</h2>
           <button
             onClick={onClose}
             className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
@@ -40,7 +40,7 @@ export default function Settings({ onClose }: SettingsProps) {
         <div className="space-y-4">
           <div>
             <label className="block text-sm font-medium mb-2">
-              瞑想の時間
+              Meditation duration
             </label>
             <div className="grid grid-cols-4 gap-2">
               {MEDITATION_OPTIONS.map(minutes => (
@@ -55,7 +55,7 @@ export default function Settings({ onClose }: SettingsProps) {
                       : 'bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600'
                   }`}
                 >
-                  {minutes}分
+                  {minutes} min
                 </button>
               ))}
             </div>
@@ -63,7 +63,7 @@ export default function Settings({ onClose }: SettingsProps) {
 
           <div>
             <label className="block text-sm font-medium mb-2">
-              メモ書きの時間（1ページあたり）
+              Journaling duration (per page)
             </label>
             <div className="grid grid-cols-3 gap-2">
               {JOURNALING_OPTIONS.map(seconds => (
@@ -78,7 +78,7 @@ export default function Settings({ onClose }: SettingsProps) {
                       : 'bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600'
                   }`}
                 >
-                  {seconds < 60 ? `${seconds}秒` : `${seconds / 60}分`}
+                  {seconds < 60 ? `${seconds}s` : `${seconds / 60} min`}
                 </button>
               ))}
             </div>
@@ -86,7 +86,7 @@ export default function Settings({ onClose }: SettingsProps) {
 
           <div>
             <label className="block text-sm font-medium mb-2">
-              休憩時間（ページ間）
+              Break duration (between pages)
             </label>
             <div className="grid grid-cols-5 gap-2">
               {BREAK_OPTIONS.map(seconds => (
@@ -101,7 +101,7 @@ export default function Settings({ onClose }: SettingsProps) {
                       : 'bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600'
                   }`}
                 >
-                  {seconds}秒
+                  {seconds}s
                 </button>
               ))}
             </div>
@@ -113,13 +113,13 @@ export default function Settings({ onClose }: SettingsProps) {
             onClick={handleSave}
             className="flex-1 px-4 py-2 bg-green-600 text-white rounded-lg font-medium hover:bg-green-700 transition-colors"
           >
-            保存
+            Save
           </button>
           <button
             onClick={onClose}
             className="flex-1 px-4 py-2 bg-gray-300 dark:bg-gray-600 text-gray-800 dark:text-white rounded-lg font-medium hover:bg-gray-400 dark:hover:bg-gray-500 transition-colors"
           >
-            キャンセル
+            Cancel
           </button>
         </div>
       </div>

--- a/components/__tests__/History.test.tsx
+++ b/components/__tests__/History.test.tsx
@@ -30,23 +30,22 @@ describe('History', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // デフォルトのモック実装
     (storage.getSessions as jest.Mock).mockReturnValue([]);
     (storage.getStreak as jest.Mock).mockReturnValue(0);
   });
 
   describe('初期表示', () => {
-    it('データなし時は「まだ記録がありません」が表示される', () => {
+    it('データなし時は「No records yet」が表示される', () => {
       render(<History />);
-      expect(screen.getByText('まだ記録がありません')).toBeInTheDocument();
+      expect(screen.getByText('No records yet')).toBeInTheDocument();
     });
 
     it('データあり時はセッション一覧が表示される', () => {
       (storage.getSessions as jest.Mock).mockReturnValue(mockSessions);
       render(<History />);
-      expect(screen.queryByText('まだ記録がありません')).not.toBeInTheDocument();
-      expect(screen.getAllByText('瞑想').length).toBeGreaterThan(0);
-      expect(screen.getByText('メモ書き')).toBeInTheDocument();
+      expect(screen.queryByText('No records yet')).not.toBeInTheDocument();
+      expect(screen.getAllByText('Meditation').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Journaling').length).toBeGreaterThan(0);
     });
 
     it('初回レンダリング時にstorageからデータを読み込む', () => {
@@ -64,25 +63,29 @@ describe('History', () => {
 
     it('ストリーク（連続記録日数）が表示される', () => {
       render(<History />);
-      const streakCard = screen.getByText('連続記録日数').parentElement;
+      const streakCard = screen.getByText('Streak').parentElement;
       expect(streakCard).toHaveTextContent('5');
     });
 
     it('瞑想回数が正しく集計される', () => {
       render(<History />);
-      const meditationCard = screen.getByText('瞑想回数').parentElement;
-      expect(meditationCard).toHaveTextContent('2'); // mockSessions内の瞑想は2件
+      const meditationCard = screen.getAllByText('Meditation').find(
+        el => el.parentElement?.className.includes('from-purple-500')
+      )?.parentElement;
+      expect(meditationCard).toHaveTextContent('2');
     });
 
     it('メモ書き回数が正しく集計される', () => {
       render(<History />);
-      const journalingCard = screen.getByText('メモ書き回数').parentElement;
-      expect(journalingCard).toHaveTextContent('1'); // mockSessions内のメモ書きは1件
+      const journalingCard = screen.getAllByText('Journaling').find(
+        el => el.parentElement?.className.includes('from-blue-500')
+      )?.parentElement;
+      expect(journalingCard).toHaveTextContent('1');
     });
 
     it('合計時間（分）が正しく集計される', () => {
       render(<History />);
-      const totalCard = screen.getByText('合計時間（分）').parentElement;
+      const totalCard = screen.getByText('Total (min)').parentElement;
       // 300 + 600 + 65 = 965秒 = 16分（切り捨て）
       expect(totalCard).toHaveTextContent('16');
     });
@@ -95,7 +98,7 @@ describe('History', () => {
 
     it('瞑想セッションは紫のバッジで表示される', () => {
       render(<History />);
-      const meditationBadges = screen.getAllByText('瞑想');
+      const meditationBadges = screen.getAllByText('Meditation').filter(el => el.tagName === 'SPAN');
       meditationBadges.forEach((badge) => {
         expect(badge).toHaveClass('bg-purple-200', 'text-purple-800');
       });
@@ -103,7 +106,7 @@ describe('History', () => {
 
     it('メモ書きセッションは青のバッジで表示される', () => {
       render(<History />);
-      const journalingBadge = screen.getByText('メモ書き');
+      const journalingBadge = screen.getAllByText('Journaling').find(el => el.tagName === 'SPAN')!;
       expect(journalingBadge).toHaveClass('bg-blue-200', 'text-blue-800');
     });
   });
@@ -122,10 +125,10 @@ describe('History', () => {
       (window.confirm as jest.Mock).mockReturnValue(false);
       render(<History />);
 
-      const deleteButtons = screen.getAllByText('削除');
+      const deleteButtons = screen.getAllByText('Delete');
       fireEvent.click(deleteButtons[0]);
 
-      expect(window.confirm).toHaveBeenCalledWith('この記録を削除しますか?');
+      expect(window.confirm).toHaveBeenCalledWith('Delete this record?');
       expect(storage.deleteSession).not.toHaveBeenCalled();
     });
 
@@ -133,10 +136,10 @@ describe('History', () => {
       (window.confirm as jest.Mock).mockReturnValue(true);
       render(<History />);
 
-      const deleteButtons = screen.getAllByText('削除');
+      const deleteButtons = screen.getAllByText('Delete');
       fireEvent.click(deleteButtons[0]);
 
-      expect(window.confirm).toHaveBeenCalledWith('この記録を削除しますか?');
+      expect(window.confirm).toHaveBeenCalledWith('Delete this record?');
       expect(storage.deleteSession).toHaveBeenCalledWith('1');
       expect(storage.getSessions).toHaveBeenCalledTimes(2); // 初回 + 削除後のリロード
     });

--- a/components/__tests__/JournalingTimer.test.tsx
+++ b/components/__tests__/JournalingTimer.test.tsx
@@ -35,29 +35,29 @@ describe('JournalingTimer', () => {
   describe('初期表示', () => {
     it('開始前は設定画面のメモ書き時間が表示される', () => {
       render(<JournalingTimer />);
-      expect(screen.getByText(/1分/)).toBeInTheDocument();
+      expect(screen.getByText(/1 min/)).toBeInTheDocument();
     });
 
-    it('「10ページ」と表示される', () => {
+    it('「10 pages」と表示される', () => {
       render(<JournalingTimer />);
-      expect(screen.getByText(/10ページ/)).toBeInTheDocument();
+      expect(screen.getByText(/10 pages/)).toBeInTheDocument();
     });
 
     it('休憩時間が表示される', () => {
       render(<JournalingTimer />);
-      expect(screen.getByText(/休憩時間: 10秒/)).toBeInTheDocument();
+      expect(screen.getByText(/Break: 10s/)).toBeInTheDocument();
     });
 
-    it('「開始」ボタンが表示される', () => {
+    it('「Start」ボタンが表示される', () => {
       render(<JournalingTimer />);
-      expect(screen.getByRole('button', { name: '開始' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Start' })).toBeInTheDocument();
     });
   });
 
   describe('タイマー開始', () => {
-    it('「開始」ボタンをクリックするとタイマーが開始される', () => {
+    it('「Start」ボタンをクリックするとタイマーが開始される', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       expect(screen.getByText('1:00')).toBeInTheDocument();
     });
@@ -69,21 +69,21 @@ describe('JournalingTimer', () => {
       });
       render(<JournalingTimer />);
 
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       expect(screen.getByText('2:00')).toBeInTheDocument();
     });
 
-    it('「ページ 1 / 10」と表示される', () => {
+    it('「Page 1 / 10」と表示される', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
-      expect(screen.getByText('ページ 1 / 10')).toBeInTheDocument();
+      expect(screen.getByText('Page 1 / 10')).toBeInTheDocument();
     });
 
     it('カウントダウンが表示される', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(1000);
@@ -96,28 +96,28 @@ describe('JournalingTimer', () => {
   describe('ページ進行インジケーター', () => {
     it('書き込み中ページは青丸（点滅）で表示される', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       const indicators = screen.getAllByTestId('page-indicator');
       expect(indicators[0]).toHaveClass('bg-blue-400 animate-pulse');
     });
-  
+
     it('休憩中は現在のページが黄丸（点滅）で表示される', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
-  
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+
       act(() => {
         jest.advanceTimersByTime(60 * 1000);
       });
-  
+
       const indicators = screen.getAllByTestId('page-indicator');
       expect(indicators[0]).toHaveClass('bg-yellow-400 animate-pulse');
     });
-  
+
     it('完了ページは青丸で表示される', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
-  
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+
       // 1ページ目完了
       act(() => {
         jest.advanceTimersByTime(60 * 1000);
@@ -126,7 +126,7 @@ describe('JournalingTimer', () => {
       act(() => {
         jest.advanceTimersByTime(10 * 1000);
       });
-  
+
       const indicators = screen.getAllByTestId('page-indicator');
       // 1ページ目は完了
       expect(indicators[0]).toHaveClass('bg-blue-600');
@@ -136,15 +136,12 @@ describe('JournalingTimer', () => {
 
     it('未完了ページはグレー丸で表示される', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       const indicators = screen.getAllByTestId('page-indicator');
       expect(indicators[9]).toHaveClass('bg-gray-300');
     });
   });
-  
-  // Add data-testid to the indicator divs in JournalingTimer.tsx
-  // <div key={i} data-testid="page-indicator" className={...} />
 
   describe('カウントダウン音', () => {
     const mockPlay = jest.fn().mockResolvedValue(undefined);
@@ -157,7 +154,7 @@ describe('JournalingTimer', () => {
 
     it('残り5秒でビープ音が鳴る', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(55 * 1000);
@@ -168,7 +165,7 @@ describe('JournalingTimer', () => {
 
     it('残り4, 3, 2, 1秒でもビープ音が鳴る', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(55 * 1000); // to 5s
@@ -183,7 +180,7 @@ describe('JournalingTimer', () => {
 
     it('残り6秒以上では鳴らない', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(54 * 1000);
@@ -201,7 +198,7 @@ describe('JournalingTimer', () => {
       }));
 
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(60 * 1000);
@@ -212,18 +209,18 @@ describe('JournalingTimer', () => {
 
     it('休憩フェーズに切り替わる', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(60 * 1000);
       });
 
-      expect(screen.getByText('休憩中')).toBeInTheDocument();
+      expect(screen.getByText('Break')).toBeInTheDocument();
     });
 
     it('休憩時間のカウントダウンが始まる', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(60 * 1000);
@@ -241,7 +238,7 @@ describe('JournalingTimer', () => {
       }));
 
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(60 * 1000); // 書き込み完了
@@ -251,13 +248,13 @@ describe('JournalingTimer', () => {
       act(() => {
         jest.advanceTimersByTime(10 * 1000); // 休憩完了
       });
-      
+
       expect(mockPlay.mock.calls.length).toBeGreaterThan(callsAfterWrite);
     });
 
     it('次のページの書き込みフェーズに切り替わる', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(60 * 1000);
@@ -266,14 +263,14 @@ describe('JournalingTimer', () => {
         jest.advanceTimersByTime(10 * 1000);
       });
 
-      expect(screen.getByText('ページ 2 / 10')).toBeInTheDocument();
+      expect(screen.getByText('Page 2 / 10')).toBeInTheDocument();
     });
 
     it('ページ番号がインクリメントされる', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
-      expect(screen.getByText('ページ 1 / 10')).toBeInTheDocument();
+      expect(screen.getByText('Page 1 / 10')).toBeInTheDocument();
 
       act(() => {
         jest.advanceTimersByTime(60 * 1000); // 1ページ完了
@@ -282,29 +279,29 @@ describe('JournalingTimer', () => {
         jest.advanceTimersByTime(10 * 1000); // 休憩完了
       });
 
-      expect(screen.getByText('ページ 2 / 10')).toBeInTheDocument();
+      expect(screen.getByText('Page 2 / 10')).toBeInTheDocument();
     });
   });
 
   describe('最終ページ（10ページ目）', () => {
     it('10ページ目完了後は休憩なしで完了する', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       for (let i = 0; i < 9; i++) {
         act(() => { jest.advanceTimersByTime(60 * 1000); });
         act(() => { jest.advanceTimersByTime(10 * 1000); });
       }
-      
-      expect(screen.getByText('ページ 10 / 10')).toBeInTheDocument();
-      
+
+      expect(screen.getByText('Page 10 / 10')).toBeInTheDocument();
+
       act(() => {
         jest.advanceTimersByTime(60 * 1000);
       });
-      
-      expect(screen.getByRole('button', { name: '開始' })).toBeInTheDocument();
+
+      expect(screen.getByRole('button', { name: 'Start' })).toBeInTheDocument();
     });
-    
+
     it('完了音が鳴る', () => {
       const mockPlay = jest.fn().mockResolvedValue(undefined);
       (global.Audio as jest.Mock).mockImplementation(() => ({
@@ -312,7 +309,7 @@ describe('JournalingTimer', () => {
       }));
 
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       for (let i = 0; i < 10; i++) {
         act(() => { jest.advanceTimersByTime(60 * 1000); });
@@ -336,14 +333,14 @@ describe('JournalingTimer', () => {
 
     it('Sessionが保存される', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
       completeTheTimer();
       expect(storage.saveSession).toHaveBeenCalled();
     });
 
     it('Session.type が "journaling" である', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
       completeTheTimer();
       expect(storage.saveSession).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'journaling' })
@@ -352,7 +349,7 @@ describe('JournalingTimer', () => {
 
     it('Session.duration が実際の経過時間（秒）である', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
       completeTheTimer();
       expect(storage.saveSession).toHaveBeenCalledWith(
         expect.objectContaining({ duration: expect.any(Number) })
@@ -362,57 +359,57 @@ describe('JournalingTimer', () => {
     it('onComplete コールバックが呼ばれる', () => {
       const onComplete = jest.fn();
       render(<JournalingTimer onComplete={onComplete} />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
       completeTheTimer();
       expect(onComplete).toHaveBeenCalled();
     });
 
     it('初期状態にリセットされる', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
       completeTheTimer();
-      expect(screen.getByRole('button', { name: '開始' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Start' })).toBeInTheDocument();
     });
   });
 
   describe('途中終了', () => {
-    it('「終了」ボタンをクリックすると確認ダイアログが表示される', () => {
+    it('「End」ボタンをクリックすると確認ダイアログが表示される', () => {
       confirmSpy.mockReturnValue(false); // Simulate user clicking "Cancel"
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
-      fireEvent.click(screen.getByRole('button', { name: '終了' }));
-      expect(confirmSpy).toHaveBeenCalledWith('メモ書きを終了しますか？');
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+      fireEvent.click(screen.getByRole('button', { name: 'End' }));
+      expect(confirmSpy).toHaveBeenCalledWith('End journaling?');
     });
 
     it('確認ダイアログでOKすると、Sessionが保存される', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(30 * 1000);
       });
 
-      fireEvent.click(screen.getByRole('button', { name: '終了' }));
+      fireEvent.click(screen.getByRole('button', { name: 'End' }));
 
       expect(storage.saveSession).toHaveBeenCalled();
     });
 
     it('確認ダイアログでOKすると、初期状態にリセットされる', () => {
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
-      fireEvent.click(screen.getByRole('button', { name: '終了' }));
-      expect(screen.getByRole('button', { name: '開始' })).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+      fireEvent.click(screen.getByRole('button', { name: 'End' }));
+      expect(screen.getByRole('button', { name: 'Start' })).toBeInTheDocument();
     });
 
     it('確認ダイアログでキャンセルすると、タイマーは続行する', () => {
       confirmSpy.mockReturnValue(false); // Simulate user clicking "Cancel"
       render(<JournalingTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
       act(() => { jest.advanceTimersByTime(1000); });
       expect(screen.getByText("0:59")).toBeInTheDocument();
-      
-      fireEvent.click(screen.getByRole('button', { name: '終了' }));
-      
+
+      fireEvent.click(screen.getByRole('button', { name: 'End' }));
+
       expect(screen.getByText("0:59")).toBeInTheDocument(); // still running
       expect(storage.saveSession).not.toHaveBeenCalled();
     });

--- a/components/__tests__/MeditationTimer.test.tsx
+++ b/components/__tests__/MeditationTimer.test.tsx
@@ -29,12 +29,12 @@ describe('MeditationTimer', () => {
   describe('初期表示', () => {
     it('開始前は設定画面の瞑想時間が表示される', () => {
       render(<MeditationTimer />);
-      expect(screen.getByText('5分')).toBeInTheDocument();
+      expect(screen.getByText('5 min')).toBeInTheDocument();
     });
 
-    it('「開始」ボタンが表示される', () => {
+    it('「Start」ボタンが表示される', () => {
       render(<MeditationTimer />);
-      expect(screen.getByRole('button', { name: '開始' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Start' })).toBeInTheDocument();
     });
 
     it('タイマーは表示されない', () => {
@@ -44,9 +44,9 @@ describe('MeditationTimer', () => {
   });
 
   describe('タイマー開始', () => {
-    it('「開始」ボタンをクリックするとタイマーが開始される', () => {
+    it('「Start」ボタンをクリックするとタイマーが開始される', () => {
       render(<MeditationTimer />);
-      const startButton = screen.getByRole('button', { name: '開始' });
+      const startButton = screen.getByRole('button', { name: 'Start' });
 
       fireEvent.click(startButton);
 
@@ -57,14 +57,14 @@ describe('MeditationTimer', () => {
       (settings.get as jest.Mock).mockReturnValue({ meditationDuration: 10 });
       render(<MeditationTimer />);
 
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       expect(screen.getByText('10:00')).toBeInTheDocument();
     });
 
     it('カウントダウンが表示される', () => {
       render(<MeditationTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(1000);
@@ -73,32 +73,32 @@ describe('MeditationTimer', () => {
       expect(screen.getByText('4:59')).toBeInTheDocument();
     });
 
-    it('「一時停止」ボタンが表示される', () => {
+    it('「Pause」ボタンが表示される', () => {
       render(<MeditationTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
-      expect(screen.getByRole('button', { name: '一時停止' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Pause' })).toBeInTheDocument();
     });
 
-    it('「停止」ボタンが表示される', () => {
+    it('「Stop」ボタンが表示される', () => {
       render(<MeditationTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
-      expect(screen.getByRole('button', { name: '停止' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument();
     });
   });
 
   describe('一時停止・再開', () => {
-    it('「一時停止」ボタンをクリックするとタイマーが停止する', () => {
+    it('「Pause」ボタンをクリックするとタイマーが停止する', () => {
       render(<MeditationTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(1000);
       });
       expect(screen.getByText('4:59')).toBeInTheDocument();
 
-      fireEvent.click(screen.getByRole('button', { name: '一時停止' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Pause' }));
 
       act(() => {
         jest.advanceTimersByTime(1000);
@@ -107,25 +107,25 @@ describe('MeditationTimer', () => {
       expect(screen.getByText('4:59')).toBeInTheDocument();
     });
 
-    it('「再開」ボタンが表示される', () => {
+    it('「Resume」ボタンが表示される', () => {
       render(<MeditationTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
-      fireEvent.click(screen.getByRole('button', { name: '一時停止' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Pause' }));
 
-      expect(screen.getByRole('button', { name: '再開' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Resume' })).toBeInTheDocument();
     });
 
-    it('「再開」ボタンをクリックするとタイマーが再開される', () => {
+    it('「Resume」ボタンをクリックするとタイマーが再開される', () => {
       render(<MeditationTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(1000);
       });
       expect(screen.getByText('4:59')).toBeInTheDocument();
 
-      fireEvent.click(screen.getByRole('button', { name: '一時停止' }));
-      fireEvent.click(screen.getByRole('button', { name: '再開' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Pause' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Resume' }));
 
       act(() => {
         jest.advanceTimersByTime(1000);
@@ -135,32 +135,32 @@ describe('MeditationTimer', () => {
   });
 
   describe('停止', () => {
-    it('「停止」ボタンをクリックするとタイマーがリセットされる', () => {
+    it('「Stop」ボタンをクリックするとタイマーがリセットされる', () => {
       render(<MeditationTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(2000);
       });
 
-      fireEvent.click(screen.getByRole('button', { name: '停止' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
 
-      expect(screen.getByText('5分')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: '開始' })).toBeInTheDocument();
+      expect(screen.getByText('5 min')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Start' })).toBeInTheDocument();
     });
 
     it('Sessionが保存されない', () => {
       render(<MeditationTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
-      fireEvent.click(screen.getByRole('button', { name: '停止' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
 
       expect(storage.saveSession).not.toHaveBeenCalled();
     });
 
     it('初期画面に戻る', () => {
       render(<MeditationTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
-      fireEvent.click(screen.getByRole('button', { name: '停止' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Stop' }));
 
       expect(screen.queryByText(/:/)).not.toBeInTheDocument();
     });
@@ -174,7 +174,7 @@ describe('MeditationTimer', () => {
       }));
 
       render(<MeditationTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(5 * 60 * 1000);
@@ -185,7 +185,7 @@ describe('MeditationTimer', () => {
 
     it('Sessionが保存される', () => {
       render(<MeditationTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(5 * 60 * 1000);
@@ -196,7 +196,7 @@ describe('MeditationTimer', () => {
 
     it('Session.type が "meditation" である', () => {
       render(<MeditationTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(5 * 60 * 1000);
@@ -211,7 +211,7 @@ describe('MeditationTimer', () => {
 
     it('Session.duration が設定時間（秒）である', () => {
       render(<MeditationTimer />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(5 * 60 * 1000);
@@ -227,7 +227,7 @@ describe('MeditationTimer', () => {
     it('onComplete コールバックが呼ばれる', () => {
       const onComplete = jest.fn();
       render(<MeditationTimer onComplete={onComplete} />);
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
 
       act(() => {
         jest.advanceTimersByTime(5 * 60 * 1000);
@@ -244,12 +244,12 @@ describe('MeditationTimer', () => {
         .mockReturnValueOnce({ meditationDuration: 10 });
 
       const { rerender } = render(<MeditationTimer />);
-      expect(screen.getByText('5分')).toBeInTheDocument();
+      expect(screen.getByText('5 min')).toBeInTheDocument();
 
       // 設定変更をシミュレート
       rerender(<MeditationTimer />);
 
-      fireEvent.click(screen.getByRole('button', { name: '開始' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Start' }));
       expect(screen.getByText('10:00')).toBeInTheDocument();
     });
   });

--- a/components/__tests__/Settings.test.tsx
+++ b/components/__tests__/Settings.test.tsx
@@ -26,30 +26,30 @@ describe('Settings', () => {
   describe('初期表示', () => {
     it('モーダルが表示される', () => {
       render(<Settings onClose={mockOnClose} />);
-      expect(screen.getByText('設定')).toBeInTheDocument();
-      expect(screen.getByText('瞑想の時間')).toBeInTheDocument();
-      expect(screen.getByText('メモ書きの時間（1ページあたり）')).toBeInTheDocument();
-      expect(screen.getByText('休憩時間（ページ間）')).toBeInTheDocument();
+      expect(screen.getByText('Settings')).toBeInTheDocument();
+      expect(screen.getByText('Meditation duration')).toBeInTheDocument();
+      expect(screen.getByText('Journaling duration (per page)')).toBeInTheDocument();
+      expect(screen.getByText('Break duration (between pages)')).toBeInTheDocument();
     });
 
     it('現在の設定値が選択状態で表示される', () => {
       render(<Settings onClose={mockOnClose} />);
 
-      // 瞑想時間: 5分が選択されている
-      const meditationSection = screen.getByText('瞑想の時間').parentElement!;
+      // 瞑想時間: 5 minが選択されている
+      const meditationSection = screen.getByText('Meditation duration').parentElement!;
       const meditation5min = within(meditationSection).getAllByRole('button').find(
-        (btn) => btn.textContent === '5分' && btn.className.includes('bg-purple-600')
+        (btn) => btn.textContent === '5 min' && btn.className.includes('bg-purple-600')
       );
       expect(meditation5min).toHaveClass('bg-purple-600', 'text-white');
 
-      // メモ書き時間: 2分（120秒）が選択されている
-      const journalingSection = screen.getByText('メモ書きの時間（1ページあたり）').parentElement!;
-      const journaling2min = within(journalingSection).getByRole('button', { name: '2分' });
+      // メモ書き時間: 2 min（120秒）が選択されている
+      const journalingSection = screen.getByText('Journaling duration (per page)').parentElement!;
+      const journaling2min = within(journalingSection).getByRole('button', { name: '2 min' });
       expect(journaling2min).toHaveClass('bg-blue-600', 'text-white');
 
-      // 休憩時間: 10秒が選択されている
-      const breakSection = screen.getByText('休憩時間（ページ間）').parentElement!;
-      const break10sec = within(breakSection).getByRole('button', { name: '10秒' });
+      // 休憩時間: 10sが選択されている
+      const breakSection = screen.getByText('Break duration (between pages)').parentElement!;
+      const break10sec = within(breakSection).getByRole('button', { name: '10s' });
       expect(break10sec).toHaveClass('bg-yellow-600', 'text-white');
     });
   });
@@ -57,8 +57,8 @@ describe('Settings', () => {
   describe('設定変更', () => {
     it('瞑想時間を変更できる', () => {
       render(<Settings onClose={mockOnClose} />);
-      const meditationSection = screen.getByText('瞑想の時間').parentElement!;
-      const meditation10min = within(meditationSection).getByRole('button', { name: '10分' });
+      const meditationSection = screen.getByText('Meditation duration').parentElement!;
+      const meditation10min = within(meditationSection).getByRole('button', { name: '10 min' });
 
       fireEvent.click(meditation10min);
 
@@ -67,8 +67,8 @@ describe('Settings', () => {
 
     it('メモ書き時間を変更できる', () => {
       render(<Settings onClose={mockOnClose} />);
-      const journalingSection = screen.getByText('メモ書きの時間（1ページあたり）').parentElement!;
-      const journaling5min = within(journalingSection).getByRole('button', { name: '5分' });
+      const journalingSection = screen.getByText('Journaling duration (per page)').parentElement!;
+      const journaling5min = within(journalingSection).getByRole('button', { name: '5 min' });
 
       fireEvent.click(journaling5min);
 
@@ -77,7 +77,7 @@ describe('Settings', () => {
 
     it('休憩時間を変更できる', () => {
       render(<Settings onClose={mockOnClose} />);
-      const break15sec = screen.getByRole('button', { name: '15秒' });
+      const break15sec = screen.getByRole('button', { name: '15s' });
 
       fireEvent.click(break15sec);
 
@@ -90,12 +90,12 @@ describe('Settings', () => {
       render(<Settings onClose={mockOnClose} />);
 
       // 設定を変更
-      const meditationSection = screen.getByText('瞑想の時間').parentElement!;
-      const meditation10min = within(meditationSection).getByRole('button', { name: '10分' });
+      const meditationSection = screen.getByText('Meditation duration').parentElement!;
+      const meditation10min = within(meditationSection).getByRole('button', { name: '10 min' });
       fireEvent.click(meditation10min);
 
       // 保存ボタンをクリック
-      const saveButton = screen.getByRole('button', { name: '保存' });
+      const saveButton = screen.getByRole('button', { name: 'Save' });
       fireEvent.click(saveButton);
 
       expect(settings.save).toHaveBeenCalledWith({
@@ -107,16 +107,16 @@ describe('Settings', () => {
     it('保存ボタンをクリックするとアラートが表示される', () => {
       render(<Settings onClose={mockOnClose} />);
 
-      const saveButton = screen.getByRole('button', { name: '保存' });
+      const saveButton = screen.getByRole('button', { name: 'Save' });
       fireEvent.click(saveButton);
 
-      expect(window.alert).toHaveBeenCalledWith('設定を保存しました');
+      expect(window.alert).toHaveBeenCalledWith('Settings saved');
     });
 
     it('保存ボタンをクリックするとonCloseが呼ばれる', () => {
       render(<Settings onClose={mockOnClose} />);
 
-      const saveButton = screen.getByRole('button', { name: '保存' });
+      const saveButton = screen.getByRole('button', { name: 'Save' });
       fireEvent.click(saveButton);
 
       expect(mockOnClose).toHaveBeenCalledTimes(1);
@@ -126,12 +126,12 @@ describe('Settings', () => {
       render(<Settings onClose={mockOnClose} />);
 
       // 設定を変更
-      const meditationSection = screen.getByText('瞑想の時間').parentElement!;
-      const meditation10min = within(meditationSection).getByRole('button', { name: '10分' });
+      const meditationSection = screen.getByText('Meditation duration').parentElement!;
+      const meditation10min = within(meditationSection).getByRole('button', { name: '10 min' });
       fireEvent.click(meditation10min);
 
       // キャンセルボタンをクリック
-      const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+      const cancelButton = screen.getByRole('button', { name: 'Cancel' });
       fireEvent.click(cancelButton);
 
       expect(settings.save).not.toHaveBeenCalled();
@@ -140,7 +140,7 @@ describe('Settings', () => {
     it('キャンセルボタンをクリックするとonCloseが呼ばれる', () => {
       render(<Settings onClose={mockOnClose} />);
 
-      const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+      const cancelButton = screen.getByRole('button', { name: 'Cancel' });
       fireEvent.click(cancelButton);
 
       expect(mockOnClose).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## 含む変更

- #32 feat: UIテキスト英語化 (Closes #19)
  - MeditationTimer, JournalingTimer, History, Settings, app/page.tsx の全UIテキストを英語に切り替え
  - 対応テスト4ファイルも英語期待値に更新

## テスト・ビルド

✅ 全146テスト通過
✅ ビルド成功