### PR TITLE
feat: 黒ベース背景・グラデーションタイトル・タブアニメーション方向修正 (#37)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -41,7 +41,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={inter.variable}>
+    <html lang="en" className={`dark ${inter.variable}`}>
       <body className="antialiased font-sans">
         <Providers>{children}</Providers>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -82,7 +82,7 @@ export default function Home() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-neutral-50 to-neutral-100 dark:from-neutral-950 dark:to-neutral-900">
+    <div className="min-h-screen bg-gradient-to-br from-neutral-950 to-neutral-900">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Header */}
         <motion.header
@@ -130,7 +130,7 @@ export default function Home() {
           </div>
 
           {/* Title */}
-          <h1 className="text-heading-1 text-foreground mb-2">{t("page.heading")}</h1>
+          <h1 className="text-heading-1 bg-gradient-to-r from-meditation-400 to-journaling-400 bg-clip-text text-transparent mb-2">{t("page.heading")}</h1>
           <p className="text-body text-muted-foreground">{t("page.description")}</p>
         </motion.header>
 
@@ -177,9 +177,9 @@ export default function Home() {
             {activeTab === "meditation" && (
               <motion.div
                 key="meditation"
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: 20 }}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 20 }}
                 transition={appleTransition}
               >
                 <MeditationTimer onComplete={handleComplete} />
@@ -188,9 +188,9 @@ export default function Home() {
             {activeTab === "journaling" && (
               <motion.div
                 key="journaling"
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: 20 }}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 20 }}
                 transition={appleTransition}
               >
                 <JournalingTimer onComplete={handleComplete} />
@@ -199,9 +199,9 @@ export default function Home() {
             {activeTab === "history" && (
               <motion.div
                 key="history"
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: 20 }}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 20 }}
                 transition={appleTransition}
               >
                 <History key={refreshKey} />


### PR DESCRIPTION
## Summary

- `app/layout.tsx`: `<html>` に `dark` クラスを追加し、全コンポーネントの `dark:` プレフィックスを有効化する
- `app/page.tsx`: ライトモード側グラデーションを削除し、黒ベース背景のみに統一
- `app/page.tsx`: タイトルを紫→青グラデーションテキスト (`from-meditation-400 to-journaling-400`) に変更
- `app/page.tsx`: 3つのタブコンテンツのアニメーションを水平スライド (x軸) から垂直スライド (y軸、下から上へ浮かぶ動き) に修正
- `min` / `pages` / `Break` / `s` は英語で仕様維持（変更なし）

## Test Plan

- [x] `npm test` — 153件全テスト通過
- [x] `npm run build` — ビルド成功（エラー無し）
- [ ] ブラウザ目視確認: ホームページ背景が黒ベース
- [ ] ブラウザ目視確認: タイトルが紫→青グラデーションで読みやすい
- [ ] ブラウザ目視確認: タブ切り替え時にコンテンツが下から上へ浮かぶ
- [ ] ブラウザ目視確認: login/signup ページも黒ベース
- [ ] ブラウザ目視確認: JournalingTimer の min/pages/Break/s が英語のまま

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)