### PR TITLE
release: develop → main（単位文字列の国際化）

### DIFF
--- a/components/JournalingTimer.tsx
+++ b/components/JournalingTimer.tsx
@@ -181,14 +181,14 @@ export default function JournalingTimer({
                     {duration < 60 ? duration : duration / 60}
                   </span>
                   <span className="text-heading-3 text-muted-foreground">
-                    {duration < 60 ? "s" : "min"}
+                    {duration < 60 ? t("unit.sec") : t("unit.min")}
                   </span>
                   <span className="text-heading-3 text-muted-foreground">
-                    × {MAX_PAGES} pages
+                    {t("journaling.unit.pages", { total: MAX_PAGES })}
                   </span>
                 </div>
                 <p className="text-caption text-muted-foreground">
-                  Break: {breakDuration}s
+                  {t("journaling.unit.break", { duration: breakDuration })}
                 </p>
               </div>
 

--- a/components/MeditationTimer.tsx
+++ b/components/MeditationTimer.tsx
@@ -127,7 +127,7 @@ export default function MeditationTimer({
                     <span className="text-display text-meditation-700 dark:text-meditation-300">
                       {duration}
                     </span>
-                    <span className="text-caption text-muted-foreground">min</span>
+                    <span className="text-caption text-muted-foreground">{t("unit.min")}</span>
                   </div>
                 </CircularProgress>
               </div>

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -76,6 +76,11 @@ const en: Record<string, string> = {
   'auth.link.login': 'Log in',
   'auth.text.nosignup': "Don't have an account? ",
   'auth.text.withsignup': 'Already have an account? ',
+  // unit
+  'unit.min': 'min',
+  'unit.sec': 's',
+  'journaling.unit.pages': '× {total} pages',
+  'journaling.unit.break': 'Break: {duration}s',
 };
 
 const ja: Record<string, string> = {
@@ -142,6 +147,11 @@ const ja: Record<string, string> = {
   'auth.link.login': 'ログインへ',
   'auth.text.nosignup': 'アカウント未持ちの方は',
   'auth.text.withsignup': 'アカウント済みの方は',
+  // unit
+  'unit.min': '分',
+  'unit.sec': '秒',
+  'journaling.unit.pages': '× {total} ページ',
+  'journaling.unit.break': '準備: {duration}秒',
 };
 
 export const translations: Record<Language, Record<string, string>> = { en, ja };


### PR DESCRIPTION
## Summary

develop に蓄積された以下の変更を main にリリースする。

- **#40** 単位文字列の国際化 — min/s/pages/Break を t() で管理
  - ja: 分・秒・ページ・準備 に対応

## 変更ファイル

- `lib/i18n.tsx` — unit キー 4件追加（en・ja）
- `components/MeditationTimer.tsx` — `min` → `t("unit.min")`
- `components/JournalingTimer.tsx` — 4箇所を t() に置換

## Test Plan

- [x] 全テスト 153件通過
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)