### PR TITLE
fix: middleware に matcher を追加し静的アセットの傍受を防止 (#43)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -3,6 +3,12 @@ import { auth } from './auth';
 
 const PUBLIC_ROUTES = ['/login', '/signup'];
 
+export const config = {
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|manifest.json).*)',
+  ],
+};
+
 export default async function middleware(request: { nextUrl: URL }) {
   const { nextUrl } = request;
   const session = await auth();


### PR DESCRIPTION
## Summary

デプロイ後に画面がまっ白になるバグを修正した。

`middleware.ts` に `matcher` 設定がなかったため、`/_next/static/`（JS・CSS チャンク）を含む全リクエストにミドルウェアが実行され、静的アセットが HTML で返されていた。`config.matcher` を追加し、静的アセット・favicon・manifest.json などを対象外にした。

## 変更ファイル

- `middleware.ts` — `config.matcher` を追加

## Test Plan

- [x] `npm test` — 153件全テスト通過
- [x] `npm run build` — ビルド成功
- [ ] Vercel デプロイ後で画面が正常に表示されること

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)