### PR TITLE
fix: auth.ts の db インポートを動的インポートに変更し Edge Runtime エラーを修正 (#46)

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -1,6 +1,5 @@
 import NextAuth from 'next-auth';
 import Credentials from 'next-auth/providers/credentials';
-import { db, users } from './lib/db';
 import { eq } from 'drizzle-orm';
 import { verifyPassword } from './lib/auth/utils';
 
@@ -18,6 +17,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
         const email = credentials.email as string;
         const password = credentials.password as string;
+
+        // Edge Runtime で db モジュールを読み込まないよう動的インポート
+        const { db, users } = await import('./lib/db');
 
         // ユーザーをデータベースから検索
         const [user] = await db


### PR DESCRIPTION
## Summary

デプロイ後の `500: MIDDLEWARE_INVOCATION_FAILED` を修正した。

`auth.ts` が `lib/db`（postgres-js）を静的インポートしていたため、ミドルウェアが `auth` をインポートすると postgres クライアントも読み込まれ、Vercel Edge Runtime で動作できなかった。`authorize` コールバック内で動的インポートに変更し、ミドルウェアの JWT セッション確認時には DB モジュールが読み込まれなくなった。

## 変更ファイル

- `auth.ts` — `import { db, users }` を `authorize` 内の `await import('./lib/db')` に移動

## Test Plan

- [x] `npm test` — 153件全テスト通過
- [x] `npm run build` — ビルド成功
- [ ] Vercel デプロイ後で `MIDDLEWARE_INVOCATION_FAILED` が解消されること

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)