### PR TITLE
feat: Claude Code hooks 導入 — シークレット検出・main直接コミット防止

### DIFF
--- a/.claude/hooks/check-secrets.sh
+++ b/.claude/hooks/check-secrets.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# シークレット検出チェック
+# PostToolUse (Edit|Write) で .ts/.tsx ファイル編集時に発火し、シークレットが混んでる場合は警告する
+
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# ファイルパスが取得できない場合は終了
+[ -z "$FILE" ] && exit 0
+
+# TypeScript ファイルのみ対象
+[[ "$FILE" =~ \.(ts|tsx)$ ]] || exit 0
+
+# テスト・モックファイルは除外
+[[ "$FILE" =~ __tests__ ]] && exit 0
+[[ "$FILE" =~ \.test\. ]] && exit 0
+[[ "$FILE" =~ \.mock\. ]] && exit 0
+
+# ファイルが存在しない場合は終了
+[ ! -f "$FILE" ] && exit 0
+
+WARNED=0
+
+# JWT トークン検出（Supabase キーなど）
+# data:audio/ や data:image/ のbase64データは除外
+MATCHES=$(grep -n 'eyJhbGci' "$FILE" | grep -v 'data:')
+if [ -n "$MATCHES" ]; then
+  echo "⚠️  潜在的なシークレット検出: $FILE" >&2
+  echo "   JWT トークン（Supabase キーなど）がコード内に混んでいないか確認してください。" >&2
+  echo "$MATCHES" >&2
+  WARNED=1
+fi
+
+# PostgreSQL 接続文字列検出
+MATCHES=$(grep -n 'postgresql://' "$FILE")
+if [ -n "$MATCHES" ]; then
+  echo "⚠️  潜在的なシークレット検出: $FILE" >&2
+  echo "   DATABASE_URL がコード内に混んでいないか確認してください。" >&2
+  echo "$MATCHES" >&2
+  WARNED=1
+fi
+
+# 警告があった場合は exit 1（PostToolUse なのでブロックにはならないが stderr で表示）
+[ "$WARNED" -eq 1 ] && exit 1
+
+exit 0

--- a/.claude/hooks/prevent-main-commit.sh
+++ b/.claude/hooks/prevent-main-commit.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# main ブランチへの直接コミット防止
+# PreToolUse (Bash) で git commit の際に発火し、main の場合は exit 2 でブロックする
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# git commit コマンドのみ対象
+echo "$COMMAND" | grep -q 'git commit' || exit 0
+
+# 現在のブランチを確認
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+if [ "$BRANCH" = "main" ]; then
+  echo "🚫 main ブランチへの直接コミットは禁止です。" >&2
+  echo "   develop へチェックアウトしてから作業してください。" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prevent-main-commit.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-secrets.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Claude Code hooks を導入し、開発時の安全网を追加した。

### 追加したホーク

| Hook | イベント | 動作 |
|------|----------|------|
| `prevent-main-commit.sh` | PreToolUse (Bash) | `git commit` で `main` ブランチを検知し exit 2 でブロック |
| `check-secrets.sh` | PostToolUse (Edit\|Write) | `.ts/.tsx` 編集時に JWT トークン・PostgreSQL接続文字列を検知し警告 |

### 変更ファイル

- `.claude/settings.json` — hooks 定義
- `.claude/hooks/prevent-main-commit.sh` — main 直接コミット防止
- `.claude/hooks/check-secrets.sh` — シークレット検出

## Test Plan

- [x] develop 上の `git commit` → 通過（exit 0）
- [x] `npm test` など非コミットコマンド → 通過（exit 0）
- [x] JWT トークン混在ファイル → 警告検出（exit 1）
- [x] クリーンなファイル → 通過（exit 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)