### PR TITLE
docs: Rules導入 — security・git-workflow を .claude/rules/ に分離

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,54 @@
+# Git Workflow Rules
+
+## ブランチ構成
+
+| ブランチ | 役割 |
+|---------|------|
+| `main` | 本番環境用（安定版のみ） |
+| `develop` | 開発用メインブランチ |
+| `feature/issue-X-description` | 機能開発用 |
+| `bugfix/issue-X-description` | バグ修正用 |
+| `hotfix/issue-X-description` | 緊急修正用（リリース済みバグのみ） |
+
+ブランチ名は `/create-gh-branch X` スキルで自動生成される。
+
+## ブランチポリシー
+
+| 変更の種類 | 作業ブランチ | PR先 |
+|-----------|------------|------|
+| 機能開発 | `feature/issue-X-description` | `develop` |
+| バグ修正 | `bugfix/issue-X-description` | `develop` |
+| ドキュメント・サブエージェント変更 | `develop` | `main` |
+| 緊急修正（リリース済みバグのみ） | `hotfix/issue-X-description` | `main` + `develop` |
+
+## 運用ルール
+
+1. **main へのコミットは絶対に行わない** — すべての変更は `develop` か `feature/*` で行う。`main` へのマージは PR のみ。PreToolUse ホーク（`prevent-main-commit.sh`）で自動ブロックされる。
+2. **常駐ブランチの保護** — `main` と `develop` は削除禁止（常に保持）。
+3. **作業ブランチのライフサイクル** — `feature/*`, `bugfix/*` はタスク完了後に必ず削除。PRマージ直後に `git branch -d` で削除する。
+4. **ローカルの理想状態** — タスク終了後は `main` と `develop` の2つのみ残す。
+5. **差分の解消** — 作業終了時は `git status` で "working tree clean" の状態にする。
+
+## Issue クローズの扱い
+
+GitHub の `Closes #X` キーワードはデフォルトブランチ（`main`）へのマージ時のみ動作する。
+このプロジェクトでは `feature → develop` へマージするため、**PRマージ直後に必ず `update_issue` で `state: "closed"` とセットする**。
+
+## コミット時の自動チェック
+
+AIがコミットを実行する前に以下を確認する：
+
+1. `git rev-parse --abbrev-ref HEAD` で現在のブランチを確認
+2. `main` の場合は拒否し、`develop` へのチェックアウトを促す
+3. `feature/*` の場合はそのままコミット・プッシュ
+4. `develop` の場合はコミット・プッシュ後、`develop → main` へのPRを自動確認
+
+## Issue 無しの変更ワークフロー
+
+Issueと紐付かない変更（ドキュメント、サブエージェント、設定等）の場合：
+
+1. `develop` へチェックアウト
+2. 変更実装・コミット
+3. `develop → main` へのPR作成（GitHub MCP）
+4. ユーザー承認後、PRマージ
+5. ローカルの `main` を更新

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,24 @@
+# Security Rules
+
+## シークレット取り扱い
+
+- `.env.local` のみで環境変数を管理し、`.gitignore` で追加済み
+- コード中に JWT トークン（`eyJhbGci` で始まる文字列）や `postgresql://` 接続文字列を埋め込むことは禁止
+- PostToolUse ホーク（`check-secrets.sh`）がコミット前に自動検出し警告する
+
+## 認証
+
+- パスワード: `bcryptjs` でハッシュ化（平文保存禁止）
+- 認証フレームワーク: NextAuth.js v5 (beta.30)、JWT セッション
+- Credentials プロバイダーのみ使用（OAuth は現時点で未導入）
+
+## 入力検証
+
+- サーバー・クライアント共用スキーマを `Zod` で定義（`lib/auth/validation.ts`）
+- バリデーション済みでない外部入力はDBに投入しない
+
+## コード規約
+
+- `any` 型は使用禁止（TypeScript strict モード）
+- インターフェース定義は `types/index.ts` に集約
+- Edge Runtime で動作しないパッケージ（`postgres` など）は動的インポートのみで読み込む

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,67 +250,9 @@ PRを確認して「マージ承認」
 
 ---
 
-### ブランチ戦略
+### ブランチ戦略・Git ワークフロー
 
-**ブランチ構成**:
-- `main`: 本番環境用（安定版のみ）
-- `develop`: 開発用メインブランチ
-- `feature/issue-X-description`: 機能開発用
-- `bugfix/issue-X-description`: バグ修正用
-
-**命名規則**:
-- GitHub Issueと連携: `feature/issue-3-meditation-timer`
-- `/create-gh-branch X` コマンドで自動生成されます
-
-**変更種類ごとのブランチポリシー**:
-
-| 変更の種類 | 作業ブランチ | PR先 |
-|-----------|------------|------|
-| 機能開発 | `feature/issue-X-description` | `develop` |
-| バグ修正 | `bugfix/issue-X-description` | `develop` |
-| ドキュメント・サブエージェント変更 | `develop` | `main` |
-| 緊急修正（リリース済みバグのみ） | `hotfix/issue-X-description` | `main` + `develop` |
-
-**マージフロー**:
-1. `feature/*` または `bugfix/*` → `develop`: 機能追加・バグ修正時
-2. `develop` → `main`: リリース時（安定版）
-3. `hotfix/*` → `main` + `develop`: 緊急修正時のみ
-
-**運用ルール**:
-1. **mainへの直接コミットは絶対に行わない**: すべての変更は `develop` か `feature/*` で行う。`main` へのマージは PRのみ。
-2. **常駐ブランチの保護**: `main` と `develop` は削除禁止（常に保持）
-3. **作業ブランチのライフサイクル**:
-   - `feature/*`, `bugfix/*` はタスク完了後に必ず削除
-   - PRマージ後、ローカルブランチを即座に削除: `git branch -d feature/issue-X-...`
-4. **ローカルの理想状態**: タスク終了後は `main` と `develop` の2つのみ残す
-5. **差分の解消**: 作業終了時は `git status` で "working tree clean" の状態にする
-
----
-
-### Issue無しの変更ワークフロー
-
-Issueと紐付かない変更（ドキュメント、サブエージェント、設定等）の場合：
-
-```
-1. develop へチェックアウト
-2. 変更実装・コミット
-3. develop → main へのPR作成（GitHub MCP）
-4. ユーザー承認後、PRマージ
-5. ローカルの main を更新
-```
-
----
-
-### AIの動作ルール（コミット時の自動チェック）
-
-AIがコミットを実行する前に、必ず以下を確認する：
-
-1. **現在のブランチを確認**: `git rev-parse --abbrev-ref HEAD`
-2. **main の場合は拒否**:
-   - `develop` へチェックアウト
-   - ユーザーに確認: 「mainへの直接コミットは禁止です。developでコミットしますか？」
-3. **feature/* の場合**: そのままコミット・プッシュ
-4. **develop の場合**: コミット・プッシュ後、`develop → main` へのPRを自動確認
+詳細は `.claude/rules/git-workflow.md` を参照。
 
 ---
 
@@ -707,7 +649,4 @@ claude mcp list
 
 ### セキュリティ
 
-- パスワード: bcryptjs（ハッシュ化）
-- 環境変数保護（.env.local、Gitignore済み）
-- 入力検証: Zod
-- 認証: NextAuth.js v5 (beta.30)、JWT セッション
+詳細は `.claude/rules/security.md` を参照。


### PR DESCRIPTION
## Summary

- `.claude/rules/security.md` を新規作成（シークレット取り扱い・認証・入力検証・コード規約）
- `.claude/rules/git-workflow.md` を新規作成（ブランチ構成・ポリシー・運用ルール・Issue クローズ手順・コミット時チェック）
- `CLAUDE.md` の該当セクションを `.claude/rules/` へのポインタに置換し、重複を排除

## Test plan

- [ ] `.claude/rules/security.md` の内容がセキュリティポリシーを正確に反映していること
- [ ] `.claude/rules/git-workflow.md` の内容がブランチ戦略・運用ルールを正確に反映していること
- [ ] `CLAUDE.md` のポインタが正しいファイルパスを参照していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)