### PR TITLE
docs: commands/ を skills/ に移動し commands/ を削除

### DIFF
--- a/.claude/skills/create-gh-branch/SKILL.md
+++ b/.claude/skills/create-gh-branch/SKILL.md
@@ -1,20 +1,21 @@
 ---
 name: create-gh-branch
 description: GitHub MCPを使い、Issue情報に基づいてGitブランチを生成し、チェックアウトします。
+disable-model-invocation: true
+argument-hint: "[issue-number]"
 ---
 
 # 概要
 
-指定されたGitHub Issue番号を基に、**GitHub MCP** を通じてIssue情報を自動取得し、命名規則に従ったブランチ名を生成します。その後、そのブランチを作成し、チェックアウトします。
+指定されたGitHub Issue番号（`$ARGUMENTS`）を基に、**GitHub MCP** を通じてIssue情報を自動取得し、命名規則に従ったブランチ名を生成します。その後、そのブランチを作成し、チェックアウトします。
 
 # 前提条件
 
 - GitHub MCPがインストールされ、利用可能な状態であること。
-- ユーザーはコマンドの引数としてIssue番号のみを与えます。
 
 # 処理フロー
 
-1.  **Issue情報の取得**: **GitHub MCPの `issues.get_issue` ツール**を利用して、指定されたIssue番号のタイトルを取得します。
+1.  **Issue情報の取得**: **GitHub MCPの `issues.get_issue` ツール**を利用して、Issue番号 `$ARGUMENTS` のタイトルを取得します。
 2.  **ブランチ名の生成**: 取得したIssue番号とタイトルを「ブランチ命名規則」に従って整形し、ブランチ名を生成します。
 3.  **ブランチの作成とチェックアウト**: Bashコマンド (`git checkout -b`) を利用して、生成された名前のブランチを作成し、チェックアウトします。
 

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: tdd
 description: TDDサイクル（Red→Green→Refactor）を実行し、テスト作成→実装→リファクタリングまで導く。
+disable-model-invocation: true
 ---
 
 # TDD サイクル

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ rm -rf .next
 
 #### Step 2-4: TDDサイクル（Red → Green → Refactor）
 
-`/tdd` スキルを使用。詳細は `.claude/commands/tdd.md` を参照。
+`/tdd` スキルを使用。詳細は `.claude/skills/tdd/SKILL.md` を参照。
 
 ---
 


### PR DESCRIPTION
## Summary

- `tdd` と `create-gh-branch` を `.claude/commands/` から `.claude/skills/` へ移動
- 両スキルに `disable-model-invocation: true` を付与（ユーザー手動のみ）
- `create-gh-branch` に `argument-hint: "[issue-number]"` と `$ARGUMENTS` プレースホルダーを追加
- `.claude/commands/` ディレクトリを削除
- `CLAUDE.md` の参照パスを更新

## Test plan

- [ ] `/tdd` が Claude Code で呼び出せること
- [ ] `/create-gh-branch` が Claude Code で呼び出せること
- [ ] 両スキルが Claude が自動で起動しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)