### PR TITLE
docs: review スキルの自動呼び出しを有効にする

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: review
 description: コード・PRのレビューを実行し、重要度順に課題を報告する。
-disable-model-invocation: true
 argument-hint: "[file-or-pr-number]"
 allowed-tools: Read, Grep, Glob, Bash(git *)
 ---


### PR DESCRIPTION
## Summary

- `review` スキルの frontmatter から `disable-model-invocation: true` を削除
- Claude がコード編集やコミット前のタイミングで自動でレビューを実行できるようにする
- `tdd`・`create-gh-branch` は副作用があるため手動のままとする

🤖 Generated with [Claude Code](https://claude.com/claude-code)