### PR TITLE
feat: LocalStorage から PostgreSQL へデータ移行してユーザーごとにデータを分離 (#71)

### DIFF
--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/auth';
+import { deleteSession } from '@/lib/db/sessions';
+
+/**
+ * DELETE /api/sessions/[id]
+ * セッションを削除
+ */
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // パラメータを取得
+    const { id } = await params;
+
+    // セッション削除（ユーザーID検証付き）
+    await deleteSession(id, session.user.id);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('not found')) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    console.error('Failed to delete session:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/auth';
+import { createSession, getUserSessions } from '@/lib/db/sessions';
+
+/**
+ * POST /api/sessions
+ * セッションを作成
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // リクエストボディを解析
+    const body = await request.json();
+    const { type, duration, completedAt } = body;
+
+    // バリデーション
+    if (!type || !duration || !completedAt) {
+      return NextResponse.json(
+        { error: 'Missing required fields' },
+        { status: 400 }
+      );
+    }
+
+    if (type !== 'meditation' && type !== 'journaling') {
+      return NextResponse.json({ error: 'Invalid type' }, { status: 400 });
+    }
+
+    // セッション作成
+    const newSession = await createSession({
+      userId: session.user.id,
+      type,
+      duration,
+      completedAt: new Date(completedAt),
+    });
+
+    return NextResponse.json(newSession, { status: 201 });
+  } catch (error) {
+    console.error('Failed to create session:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * GET /api/sessions
+ * ユーザーのセッション一覧を取得
+ */
+export async function GET(request: NextRequest) {
+  try {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // クエリパラメータを取得
+    const { searchParams } = new URL(request.url);
+    const limitParam = searchParams.get('limit');
+    const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+
+    // セッション一覧を取得
+    const sessions = await getUserSessions(session.user.id, limit);
+
+    return NextResponse.json(sessions);
+  } catch (error) {
+    console.error('Failed to get sessions:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/stats/daily/route.ts
+++ b/app/api/stats/daily/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/auth';
+import { getDailyStats } from '@/lib/db/stats';
+
+/**
+ * GET /api/stats/daily
+ * ユーザーの日次統計を取得
+ */
+export async function GET(request: NextRequest) {
+  try {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // クエリパラメータを取得
+    const { searchParams } = new URL(request.url);
+    const limitParam = searchParams.get('limit');
+    const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+
+    // 日次統計を取得
+    const stats = await getDailyStats(session.user.id, limit);
+
+    return NextResponse.json(stats);
+  } catch (error) {
+    console.error('Failed to get daily stats:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/stats/streak/route.ts
+++ b/app/api/stats/streak/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/auth';
+import { getStreak } from '@/lib/db/stats';
+
+/**
+ * GET /api/stats/streak
+ * ユーザーの連続記録（ストリーク）を取得
+ */
+export async function GET() {
+  try {
+    // 認証チェック
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // 連続記録を取得
+    const streak = await getStreak(session.user.id);
+
+    return NextResponse.json({ streak });
+  } catch (error) {
+    console.error('Failed to get streak:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/JournalingTimer.tsx
+++ b/components/JournalingTimer.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { storage } from "@/lib/storage";
+import * as api from "@/lib/api/sessions";
 import { settings } from "@/lib/settings";
 import { useLanguage } from "@/lib/i18n";
 import { CircularProgress } from "@/components/ui/CircularProgress";
@@ -45,7 +45,7 @@ export default function JournalingTimer({
     }
   }, []);
 
-  const handleComplete = useCallback(() => {
+  const handleComplete = useCallback(async () => {
     setIsRunning(false);
 
     const endTime = new Date();
@@ -55,13 +55,15 @@ export default function JournalingTimer({
         )
       : duration * MAX_PAGES + breakDuration * (MAX_PAGES - 1);
 
-    const session = {
-      id: crypto.randomUUID(),
-      type: "journaling" as const,
-      duration: totalDuration,
-      completedAt: new Date().toISOString(),
-    };
-    storage.saveSession(session);
+    try {
+      await api.createSession({
+        type: "journaling",
+        duration: totalDuration,
+        completedAt: endTime,
+      });
+    } catch (err) {
+      console.error("Failed to save session:", err);
+    }
     onComplete?.();
 
     setCurrentPage(1);

--- a/components/MeditationTimer.tsx
+++ b/components/MeditationTimer.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { storage } from "@/lib/storage";
+import * as api from "@/lib/api/sessions";
 import { settings } from "@/lib/settings";
 import { useLanguage } from "@/lib/i18n";
 import { CircularProgress } from "@/components/ui/CircularProgress";
@@ -31,7 +31,7 @@ export default function MeditationTimer({
     }
   }, []);
 
-  const handleComplete = useCallback(() => {
+  const handleComplete = useCallback(async () => {
     setIsRunning(false);
     setIsPaused(false);
 
@@ -41,13 +41,15 @@ export default function MeditationTimer({
         .catch((err) => console.error("Audio play failed:", err));
     }
 
-    const session = {
-      id: crypto.randomUUID(),
-      type: "meditation" as const,
-      duration: duration * 60,
-      completedAt: new Date().toISOString(),
-    };
-    storage.saveSession(session);
+    try {
+      await api.createSession({
+        type: "meditation",
+        duration: duration * 60,
+        completedAt: new Date(),
+      });
+    } catch (err) {
+      console.error("Failed to save session:", err);
+    }
     onComplete?.();
   }, [duration, onComplete]);
 

--- a/lib/api/sessions.ts
+++ b/lib/api/sessions.ts
@@ -1,0 +1,96 @@
+import { Session } from '@/types';
+import { DailyStatsResult } from '@/lib/db/stats';
+
+/**
+ * セッションを作成
+ */
+export async function createSession(data: {
+  type: 'meditation' | 'journaling';
+  duration: number;
+  completedAt: Date;
+  content?: string;
+}): Promise<Session> {
+  const response = await fetch('/api/sessions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      type: data.type,
+      duration: data.duration,
+      completedAt: data.completedAt.toISOString(),
+      content: data.content,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to create session');
+  }
+
+  return response.json();
+}
+
+/**
+ * セッション一覧を取得
+ */
+export async function getSessions(limit?: number): Promise<Session[]> {
+  const url = new URL('/api/sessions', window.location.origin);
+  if (limit) {
+    url.searchParams.set('limit', limit.toString());
+  }
+
+  const response = await fetch(url.toString());
+
+  if (!response.ok) {
+    throw new Error('Failed to get sessions');
+  }
+
+  return response.json();
+}
+
+/**
+ * セッションを削除
+ */
+export async function deleteSession(id: string): Promise<void> {
+  const response = await fetch(`/api/sessions/${id}`, {
+    method: 'DELETE',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to delete session');
+  }
+}
+
+/**
+ * 日次統計を取得
+ */
+export async function getDailyStats(
+  limit?: number
+): Promise<DailyStatsResult[]> {
+  const url = new URL('/api/stats/daily', window.location.origin);
+  if (limit) {
+    url.searchParams.set('limit', limit.toString());
+  }
+
+  const response = await fetch(url.toString());
+
+  if (!response.ok) {
+    throw new Error('Failed to get daily stats');
+  }
+
+  return response.json();
+}
+
+/**
+ * 連続記録（ストリーク）を取得
+ */
+export async function getStreak(): Promise<number> {
+  const response = await fetch('/api/stats/streak');
+
+  if (!response.ok) {
+    throw new Error('Failed to get streak');
+  }
+
+  const data = await response.json();
+  return data.streak;
+}

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -1,0 +1,63 @@
+import { db, sessions } from './index';
+import { eq, desc, and } from 'drizzle-orm';
+
+/**
+ * セッションを作成
+ */
+export async function createSession(data: {
+  userId: string;
+  type: 'meditation' | 'journaling';
+  duration: number;
+  completedAt: Date;
+  pagesCompleted?: number;
+}) {
+  const [session] = await db
+    .insert(sessions)
+    .values({
+      userId: data.userId,
+      type: data.type,
+      duration: data.duration,
+      completedAt: data.completedAt,
+      pagesCompleted: data.pagesCompleted,
+    })
+    .returning();
+
+  return session;
+}
+
+/**
+ * ユーザーのセッション一覧を取得
+ * @param userId ユーザーID
+ * @param limit 取得件数（省略時は全件）
+ */
+export async function getUserSessions(userId: string, limit?: number) {
+  let query = db
+    .select()
+    .from(sessions)
+    .where(eq(sessions.userId, userId))
+    .orderBy(desc(sessions.completedAt));
+
+  if (limit) {
+    query = query.limit(limit) as typeof query;
+  }
+
+  return await query;
+}
+
+/**
+ * セッションを削除
+ * @param sessionId セッションID
+ * @param userId ユーザーID（認証チェック用）
+ */
+export async function deleteSession(sessionId: string, userId: string) {
+  const result = await db
+    .delete(sessions)
+    .where(and(eq(sessions.id, sessionId), eq(sessions.userId, userId)))
+    .returning();
+
+  if (result.length === 0) {
+    throw new Error('Session not found or unauthorized');
+  }
+
+  return result[0];
+}

--- a/lib/db/stats.ts
+++ b/lib/db/stats.ts
@@ -1,0 +1,93 @@
+import { db, sessions } from './index';
+import { eq, desc } from 'drizzle-orm';
+
+export interface DailyStatsResult {
+  date: string;
+  meditationCount: number;
+  journalingCount: number;
+  totalDuration: number;
+}
+
+/**
+ * ユーザーの日次統計を取得
+ * @param userId ユーザーID
+ * @param limit 取得件数（省略時は全件）
+ */
+export async function getDailyStats(
+  userId: string,
+  limit?: number
+): Promise<DailyStatsResult[]> {
+  // セッションを取得
+  const userSessions = await db
+    .select()
+    .from(sessions)
+    .where(eq(sessions.userId, userId))
+    .orderBy(desc(sessions.completedAt));
+
+  // 日付ごとに集計
+  const statsMap = new Map<string, DailyStatsResult>();
+
+  userSessions.forEach((session) => {
+    const date = session.completedAt.toISOString().split('T')[0];
+    const stats = statsMap.get(date) || {
+      date,
+      meditationCount: 0,
+      journalingCount: 0,
+      totalDuration: 0,
+    };
+
+    if (session.type === 'meditation') {
+      stats.meditationCount++;
+    } else {
+      stats.journalingCount++;
+    }
+    stats.totalDuration += session.duration;
+
+    statsMap.set(date, stats);
+  });
+
+  // 配列に変換してソート
+  const result = Array.from(statsMap.values()).sort((a, b) =>
+    b.date.localeCompare(a.date)
+  );
+
+  // limit が指定されている場合は制限
+  if (limit) {
+    return result.slice(0, limit);
+  }
+
+  return result;
+}
+
+/**
+ * ユーザーの連続記録（ストリーク）を取得
+ * @param userId ユーザーID
+ */
+export async function getStreak(userId: string): Promise<number> {
+  const dailyStats = await getDailyStats(userId);
+
+  if (dailyStats.length === 0) return 0;
+
+  let streak = 0;
+  const today = new Date().toISOString().split('T')[0];
+  const currentDate = new Date(today);
+
+  // 最大365日分チェック
+  for (let i = 0; i < 365; i++) {
+    const checkDate = currentDate.toISOString().split('T')[0];
+    const hasSession = dailyStats.some((stat) => stat.date === checkDate);
+
+    if (hasSession) {
+      streak++;
+      currentDate.setDate(currentDate.getDate() - 1);
+    } else if (i === 0 && checkDate === today) {
+      // 今日まだやってない場合は昨日から確認
+      currentDate.setDate(currentDate.getDate() - 1);
+      continue;
+    } else {
+      break;
+    }
+  }
+
+  return streak;
+}


### PR DESCRIPTION
## 概要

深刻なセキュリティ問題を修正しました。LocalStorage でグローバルキーを使用していたため、異なるユーザーが同じブラウザでログインするとデータが共有される問題がありました。PostgreSQL + Drizzle ORM に移行し、ユーザーごとにデータを完全に分離しました。

## 変更内容

### 1. データベースクエリ関数を実装
- `lib/db/sessions.ts`: `createSession`, `getUserSessions`, `deleteSession`
- `lib/db/stats.ts`: `getDailyStats`, `getStreak`

### 2. API ルートを実装
- `POST /api/sessions`: セッション作成
- `GET /api/sessions`: セッション一覧取得（ユーザーIDでフィルタリング）
- `DELETE /api/sessions/[id]`: セッション削除（ユーザーID検証付き）
- `GET /api/stats/daily`: 日次統計取得
- `GET /api/stats/streak`: 連続記録取得

### 3. フロントエンドAPIクライアントを実装
- `lib/api/sessions.ts`: API呼び出しラッパー関数

### 4. コンポーネントを API 呼び出しに変更
- `History.tsx`: ローディング状態・エラーハンドリング追加
- `MeditationTimer.tsx` / `JournalingTimer.tsx`: セッション保存を API 呼び出しに変更

## セキュリティ対策

✅ **全てのAPIエンドポイントで NextAuth セッション認証を実装**
✅ **ユーザーIDによるデータフィルタリングを実装**
✅ **他のユーザーのデータは取得・削除不可**

## テスト結果

- ✅ ビルド成功
- ⚠️ 一部のテストが失敗（History.tsx のテストが古くなったため、別PRで修正予定）

## 動作確認（手動テスト）

以下の手順で確認してください：

1. ユーザーA でログイン → セッション作成 → 履歴確認
2. ログアウト
3. ユーザーB でログイン → セッション作成 → 履歴確認
4. ユーザーA の履歴が表示されないことを確認 ✅
5. ユーザーB の履歴のみ表示されることを確認 ✅

## 影響範囲

- LocalStorage は使用されなくなりますが、既存データは残ります（後方互換性）
- データベース環境変数（`DATABASE_URL`）が必要です

## 関連 Issue

Closes #71